### PR TITLE
vee-validateを導入#30

### DIFF
--- a/app/javascript/components/pages/RegisterPage.vue
+++ b/app/javascript/components/pages/RegisterPage.vue
@@ -3,10 +3,7 @@
     <v-card-title>
       <div class="text-h6 base--text">新規ユーザー登録</div>
     </v-card-title>
-    <validation-observer
-      ref="observer"
-      v-slot="{ handleSubmit }"
-    >
+    <validation-observer ref="observer" v-slot="{ handleSubmit }">
       <v-form @submit.prevent="handleSubmit(createUser)">
         <v-card-text>
           <template v-if="railsErrors.show">

--- a/app/javascript/components/pages/RegisterPage.vue
+++ b/app/javascript/components/pages/RegisterPage.vue
@@ -3,48 +3,86 @@
     <v-card-title>
       <div class="text-h6 base--text">新規ユーザー登録</div>
     </v-card-title>
-    <v-form @submit.prevent="createUser">
-      <v-card-text>
-        <template v-if="railsErrors.show">
-          <v-alert class="text-center" dense type="error">
-            <template v-for="e in railsErrors.errorMessages">
-              <p :key="e">{{ e }}</p>
-            </template>
-          </v-alert>
-        </template>
-        <v-text-field
-          v-model="user.name"
-          color="base"
-          dark
-          type="text"
-          label="ユーザーネーム"
-        />
-        <v-text-field
-          v-model="user.email"
-          color="base"
-          dark
-          type="email"
-          label="メールアドレス"
-        />
-        <v-text-field
-          v-model="user.password"
-          color="base"
-          dark
-          type="password"
-          label="パスワード"
-        />
-        <v-text-field
-          v-model="user.password_confirmation"
-          color="base"
-          dark
-          type="password"
-          label="パスワード（確認）"
-        />
-      </v-card-text>
-      <v-card-actions>
-        <v-btn type="submit" color="base" outlined>登録</v-btn>
-      </v-card-actions>
-    </v-form>
+    <validation-observer
+      ref="observer"
+      v-slot="{ handleSubmit }"
+    >
+      <v-form @submit.prevent="handleSubmit(createUser)">
+        <v-card-text>
+          <template v-if="railsErrors.show">
+            <v-alert class="text-center" dense type="error">
+              <template v-for="e in railsErrors.errorMessages">
+                <p :key="e">{{ e }}</p>
+              </template>
+            </v-alert>
+          </template>
+          <validation-provider
+            v-slot="{ errors }"
+            name="ユーザーネーム"
+            rules="required"
+          >
+            <v-text-field
+              v-model="user.name"
+              :error-messages="errors"
+              color="base"
+              dark
+              type="text"
+              label="ユーザーネーム"
+              required
+            />
+          </validation-provider>
+          <validation-provider
+            v-slot="{ errors }"
+            name="メールアドレス"
+            rules="email|required"
+          >
+            <v-text-field
+              v-model="user.email"
+              :error-messages="errors"
+              color="base"
+              dark
+              type="email"
+              label="メールアドレス"
+              required
+            />
+          </validation-provider>
+          <validation-provider
+            v-slot="{ errors }"
+            name="パスワード"
+            rules="alpha_num|min:5|required"
+            vid="confirmation"
+          >
+            <v-text-field
+              v-model="user.password"
+              :error-messages="errors"
+              color="base"
+              dark
+              type="password"
+              label="パスワード"
+              required
+            />
+          </validation-provider>
+          <validation-provider
+            v-slot="{ errors }"
+            name="パスワード（確認）"
+            rules="confirmed:confirmation|required"
+          >
+            <v-text-field
+              v-model="user.password_confirmation"
+              :error-messages="errors"
+              color="base"
+              dark
+              type="password"
+              label="パスワード（確認）"
+              required
+            />
+          </validation-provider>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn type="submit" color="base" outlined>登録</v-btn>
+        </v-card-actions>
+      </v-form>
+    </validation-observer>
   </v-card>
 </template>
 

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -13,6 +13,7 @@ import { csrfToken } from '@rails/ujs';
 import router from '../router/router';
 import store from '../store/index';
 import vuetify from '../vuetify/vuetify';
+import * as veeValidate from '../plugins/vee-validate';
 
 Vue.use(AxiosPlugin, { axios: axios, csrfToken: csrfToken });
 
@@ -20,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const app = new Vue({
     router,
     store,
+    veeValidate,
     vuetify,
     render: (h) => h(App),
   }).$mount();

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -4,7 +4,7 @@ import {
   ValidationProvider,
   ValidationObserver,
   extend,
-  setInteractionMode
+  setInteractionMode,
 } from 'vee-validate';
 
 import {
@@ -12,7 +12,7 @@ import {
   confirmed,
   email,
   min,
-  required
+  required,
 } from 'vee-validate/dist/rules';
 
 setInteractionMode('eager');
@@ -22,25 +22,25 @@ Vue.component('ValidationObserver', ValidationObserver);
 
 extend('alpha_num', {
   ...alpha_num,
-  message: '{_field_}は英数字のみ使用できます'
+  message: '{_field_}は英数字のみ使用できます',
 });
 
 extend('confirmed', {
   ...confirmed,
-  message: 'パスワードと一致しません'
+  message: 'パスワードと一致しません',
 });
 
 extend('email', {
   ...email,
-  message: '形式を確認してください'
+  message: '形式を確認してください',
 });
 
 extend('min', {
   ...min,
-  message: '{length}文字以上で入力してください'
+  message: '{length}文字以上で入力してください',
 });
 
 extend('required', {
   ...required,
-  message: '{_field_}を入力してください'
+  message: '{_field_}を入力してください',
 });

--- a/app/javascript/plugins/vee-validate.js
+++ b/app/javascript/plugins/vee-validate.js
@@ -1,0 +1,46 @@
+import Vue from 'vue';
+
+import {
+  ValidationProvider,
+  ValidationObserver,
+  extend,
+  setInteractionMode
+} from 'vee-validate';
+
+import {
+  alpha_num,
+  confirmed,
+  email,
+  min,
+  required
+} from 'vee-validate/dist/rules';
+
+setInteractionMode('eager');
+
+Vue.component('ValidationProvider', ValidationProvider);
+Vue.component('ValidationObserver', ValidationObserver);
+
+extend('alpha_num', {
+  ...alpha_num,
+  message: '{_field_}は英数字のみ使用できます'
+});
+
+extend('confirmed', {
+  ...confirmed,
+  message: 'パスワードと一致しません'
+});
+
+extend('email', {
+  ...email,
+  message: '形式を確認してください'
+});
+
+extend('min', {
+  ...min,
+  message: '{length}文字以上で入力してください'
+});
+
+extend('required', {
+  ...required,
+  message: '{_field_}を入力してください'
+});

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import createPersistedState from "vuex-persistedstate";
+import createPersistedState from 'vuex-persistedstate';
 
 import flashMessage from './modules/flashMessage';
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@rails/webpacker": "5.4.3",
     "axios": "^0.22.0",
     "dayjs": "^1.10.7",
+    "vee-validate": "^3.4.13",
     "vue": "^2.6.14",
     "vue-loader": "^15.9.8",
     "vue-router": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7219,6 +7219,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vee-validate@^3.4.13:
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.4.13.tgz#886ffe90778edde9c2f0c3ad94bfab3fe8079f31"
+  integrity sha512-ONnyRixpd0/JOGLuN8dlxFwLoT5FGq5ti1w4rx/zFZWaJZ1EefhfAbXkQvLwLhjU6izkfHyITXojW/7InOU3Tw==
+
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"


### PR DESCRIPTION
## 概要
vee-validateを導入し、フロントでのバリデーションを使用可能に。
また、すでに作成したユーザー新規登録ページにバリデーションを適用した。

<br />

## チェックリスト
- [x] インストール
- [x] 設定ファイルの追加
- [x] 新規ユーザー登録用フォームにバリエーションを適用
- [x] リントチェック
- [x] 動作確認

<br />

closes #30 
