### PR TITLE
PFCの割合を保存するカラムをusersテーブルに追加#41

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,7 +50,8 @@ module Admin
       def user_params
         # アクセス制限後:roleを再度追加
         params.require(:user).permit(:name, :email, :password, :password_confirmation,
-                                     :gender, :birth, :height, :weight)
+                                     :gender, :birth, :height, :weight,
+                                     :percentage_protein, :percentage_fat, :percentage_protein)
       end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,9 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  name                        :string           default("noname"), not null
+#  percentage_carbohydrate     :float            default(0.6), not null
+#  percentage_fat              :float            default(0.2), not null
+#  percentage_protein          :float            default(0.2), not null
 #  role                        :integer          default("general"), not null
 #  salt                        :string
 #  weight                      :float            default(0.0), not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   enum role: { general: 0, admin: 10 }
 
   # Validations
+  include ActiveModel::Validations
+  validates_with PfcValidator
+
   with_options presence: true do
     validates :name, length: { maximum: 50 }
     validates :email, uniqueness: { case_sensitive: false }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,10 +43,10 @@ class User < ApplicationRecord
     (Time.zone.today.strftime("%Y%m%d").to_i - birth.strftime("%Y%m%d").to_i) / 10_000
   end
 
-  # 国立健康・栄養研究所の式（Ganpule の式）を使用
   def calc_bmr
     age = calc_age
 
+    # 国立健康・栄養研究所の式（Ganpule の式）を使用
     if gender == 'female'
       (0.0481 * weight + 0.0234 * height - 0.0138 * age - 0.9708) * 1000 / 4.186
     else
@@ -54,6 +54,7 @@ class User < ApplicationRecord
     end
   end
 
+  # TODO: コントローラーの整理後不要になるかも？
   def set_attributes_for_bmr
     {
       gender: gender,
@@ -64,7 +65,27 @@ class User < ApplicationRecord
     }
   end
 
+  def set_amount_pfc
+    { 
+      protein: calc_amount_protein,
+      fat: calc_amount_fat,
+      carbohydrate: calc_amount_carbo
+    }
+  end
+
   private
+
+    def calc_amount_protein
+      bmr * percentage_protein / 4
+    end
+
+    def calc_amount_fat
+      bmr * percentage_fat / 9
+    end
+
+    def calc_amount_carbo
+      bmr * percentage_carbohydrate / 4
+    end
 
     def new_or_changes_password
       new_record? || changes[:crypted_password]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
   end
 
   def set_amount_pfc
-    { 
+    {
       protein: calc_amount_protein,
       fat: calc_amount_fat,
       carbohydrate: calc_amount_carbo

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,12 @@ class User < ApplicationRecord
       validates :weight
       validates :bmr
     end
+
+    with_options numericality: { greater_than_or_equal_to: 0.1, less_than_or_equal_to: 0.8 } do
+      validates :percentage_protein
+      validates :percentage_fat
+      validates :percentage_carbohydrate
+    end
   end
 
   validates :birth, birth: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,9 +67,9 @@ class User < ApplicationRecord
 
   def set_amount_pfc
     {
-      protein: calc_amount_protein,
-      fat: calc_amount_fat,
-      carbohydrate: calc_amount_carbo
+      protein: calc_amount_protein.floor,
+      fat: calc_amount_fat.floor,
+      carbohydrate: calc_amount_carbo.floor
     }
   end
 

--- a/app/validators/pfc_validator.rb
+++ b/app/validators/pfc_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PfcValidator < ActiveModel::Validator
   def validate(record)
     sum = record.percentage_protein +

--- a/app/validators/pfc_validator.rb
+++ b/app/validators/pfc_validator.rb
@@ -1,0 +1,14 @@
+class PfcValidator < ActiveModel::Validator
+  def validate(record)
+    sum = record.percentage_protein +
+          record.percentage_fat +
+          record.percentage_carbohydrate
+
+    unless sum == 1
+      record.errors.add(
+        :base,
+        "PFCは合計で100%になるよう設定してください"
+      )
+    end
+  end
+end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -37,6 +37,18 @@
         <%= f.number_field :weight, class: "admin-form-text" %>
       </div>
       <div class="admin-form-group">
+        <%= f.label :percentage_protein, class: "admin-form-label" %><br>
+        <%= f.number_field :percentage_protein, step: "0.1", class: "admin-form-text" %>
+      </div>
+      <div class="admin-form-group">
+        <%= f.label :percentage_fat, class: "admin-form-label" %><br>
+        <%= f.number_field :percentage_fat, step: "0.1", class: "admin-form-text" %>
+      </div>
+      <div class="admin-form-group">
+        <%= f.label :percentage_carbohydrate, class: "admin-form-label" %><br>
+        <%= f.number_field :percentage_carbohydrate, step: "0.1", class: "admin-form-text" %>
+      </div>
+      <div class="admin-form-group">
         <%= f.label :role, class: "admin-form-label" %><br>
         <%= f.select :role, User.roles_i18n.invert, {}, class: "admin-form-select" %>
       </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -40,6 +40,18 @@
         <td class="admin-t-data"><%= @user.bmr %></td>
       </tr>
       <tr class="admin-t-row">
+        <th class="admin-t-head"><%= User.human_attribute_name(:percentage_protein) %></th>
+        <td class="admin-t-data"><%= @user.percentage_protein %></td>
+      </tr>
+      <tr class="admin-t-row">
+        <th class="admin-t-head"><%= User.human_attribute_name(:percentage_fat) %></th>
+        <td class="admin-t-data"><%= @user.percentage_fat %></td>
+      </tr>
+      <tr class="admin-t-row">
+        <th class="admin-t-head"><%= User.human_attribute_name(:percentage_carbohydrate) %></th>
+        <td class="admin-t-data"><%= @user.percentage_carbohydrate %></td>
+      </tr>
+      <tr class="admin-t-row">
         <th class="admin-t-head"><%= User.human_attribute_name(:role) %></th>
         <td class="admin-t-data"><%= @user.role_i18n %></td>
       </tr>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -15,8 +15,11 @@ ja:
         height: "身長"
         weight: "体重"
         bmr: "BMR"
-        role: "権限"
+        percentage_protein: "タンパク質の割合"
+        percentage_fat: "脂質の割合"
+        percentage_carbohydrate: "炭水化物の割合"
         dietary_reference_intake_id: "食事摂取基準ID"
+        role: "権限"
         created_at: "登録日時"
         updated_at: "更新日時"
       dietary_reference_intake:

--- a/db/migrate/20211006021623_add_some_columns_for_pfc_to_users.rb
+++ b/db/migrate/20211006021623_add_some_columns_for_pfc_to_users.rb
@@ -1,0 +1,7 @@
+class AddSomeColumnsForPfcToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :percentage_protein, :float, null: false, default: 0.2
+    add_column :users, :percentage_fat, :float, null: false, default: 0.2
+    add_column :users, :percentage_carbohydrate, :float, null: false, default: 0.6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_042010) do
+ActiveRecord::Schema.define(version: 2021_10_06_021623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,9 @@ ActiveRecord::Schema.define(version: 2021_10_05_042010) do
     t.float "weight", default: 0.0, null: false
     t.float "bmr", default: 0.0, null: false
     t.bigint "dietary_reference_intake_id", default: 0, null: false
+    t.float "percentage_protein", default: 0.2, null: false
+    t.float "percentage_fat", default: 0.2, null: false
+    t.float "percentage_carbohydrate", default: 0.6, null: false
     t.index ["dietary_reference_intake_id"], name: "index_users_on_dietary_reference_intake_id"
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/db/seeds/test_user.rb
+++ b/db/seeds/test_user.rb
@@ -6,7 +6,7 @@ admin = User.create({
           role: "admin",
           gender: "male",
           birth: "1995-09-11",
-          dietary_reference_intake_id: 1
+          dietary_reference_intake_id: 2
         })
 
 general = User.create({

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,6 +17,9 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  name                        :string           default("noname"), not null
+#  percentage_carbohydrate     :float            default(0.6), not null
+#  percentage_fat              :float            default(0.2), not null
+#  percentage_protein          :float            default(0.2), not null
 #  role                        :integer          default("general"), not null
 #  salt                        :string
 #  weight                      :float            default(0.0), not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,9 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  name                        :string           default("noname"), not null
+#  percentage_carbohydrate     :float            default(0.6), not null
+#  percentage_fat              :float            default(0.2), not null
+#  percentage_protein          :float            default(0.2), not null
 #  role                        :integer          default("general"), not null
 #  salt                        :string
 #  weight                      :float            default(0.0), not null


### PR DESCRIPTION
## 概要
PFCバランスの情報を保存するカラムをusersテーブルに追加し、
バリデーションの設定とグラム数計算用のメソッドを作成した。
また、ユーザー管理画面への反映も行った。

なお割合を変更する機能の作成は後回しにし、しばらくはデフォルトの割合を使用する。

<br />


## チェックリスト
- [x] マイグレーションの作成
- [x] バリデーションの追加
- [x] %からg数を計算するメソッドの追加
- [x] ロケールファイルへの追記
- [x] 管理画面に追記
- [x] リントチェック
- [x] 動作確認

<br />

closes #41 
