### PR TITLE
マイページで使用していたコントローラーを整理#42

### DIFF
--- a/app/controllers/api/v1/bmrs_controller.rb
+++ b/app/controllers/api/v1/bmrs_controller.rb
@@ -5,13 +5,6 @@ module Api
     class BmrsController < Api::V1::BaseController
       before_action :set_user
 
-      def show
-        attributes = @user.set_attributes_for_bmr
-        json_string = attributes.to_json
-
-        render json: json_string
-      end
-
       # TODO: 1アクションの中で2度updateしている、要リファクタリング
       def update
         if @user.update(bmr_params)

--- a/app/controllers/api/v1/bmrs_controller.rb
+++ b/app/controllers/api/v1/bmrs_controller.rb
@@ -11,7 +11,7 @@ module Api
           bmr = @user.calc_bmr.floor
           @user.update!(bmr: bmr)
 
-          render json: { bmr: @user.bmr }
+          render json: { bmr: @user.bmr, pfc_params: @user.set_attributes_for_pfc }
         else
           render400(nil, @user.errors.full_messages)
         end

--- a/app/controllers/api/v1/mypages_controller.rb
+++ b/app/controllers/api/v1/mypages_controller.rb
@@ -3,8 +3,20 @@
 module Api
   module V1
     class MypagesController < Api::V1::BaseController
+      before_action :set_user
+
       def show
+        mypage_params = @user.set_mypage_params
+
+        json_string = mypage_params.to_json
+        render json: json_string
       end
+
+      private
+
+        def set_user
+          @user = User.find(current_user.id)
+        end
     end
   end
 end

--- a/app/controllers/api/v1/mypages_controller.rb
+++ b/app/controllers/api/v1/mypages_controller.rb
@@ -7,15 +7,13 @@ module Api
 
       def show
         mypage_params = @user.set_mypage_params
-
-        json_string = mypage_params.to_json
-        render json: json_string
+        render json: mypage_params
       end
 
       private
 
         def set_user
-          @user = User.find(current_user.id)
+          @user = User.includes(:dietary_reference_intake).find(current_user.id)
         end
     end
   end

--- a/app/controllers/api/v1/mypages_controller.rb
+++ b/app/controllers/api/v1/mypages_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MypagesController < Api::V1::BaseController
+      def show
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_dietary_reference_intakes_controller.rb
+++ b/app/controllers/api/v1/users_dietary_reference_intakes_controller.rb
@@ -5,15 +5,6 @@ module Api
     class UsersDietaryReferenceIntakesController < Api::V1::BaseController
       before_action :set_user
 
-      def show
-        dri = @user.dietary_reference_intake
-        json_string = DietaryReferenceIntakeSerializer
-                      .new(dri)
-                      .serialized_json
-
-        render json: json_string
-      end
-
       def update
         dri = set_reference_intake(@user)
 

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -7,10 +7,10 @@
 
       <v-tab-item class="tab-item">
         <v-row>
-          <v-col cols="12" md="4"  class="mypage-items">
+          <v-col cols="12" md="4" class="mypage-items">
             <bmr-form @click="updateBmrAndReference" />
           </v-col>
-          <v-col cols="12" md="4" class="mypage-items" >
+          <v-col cols="12" md="4" class="mypage-items">
             <my-page-dri-index />
           </v-col>
         </v-row>
@@ -39,12 +39,14 @@ export default {
   },
   methods: {
     setData() {
-      this.axios.get('/api/v1/mypage')
+      this.axios
+        .get('/api/v1/mypage')
         .then((res) => {
           console.log(res.status);
 
           const r = res.data;
           this.dispatchBmr(r.bmr_params);
+          this.dispatchPfc(r.pfc_params);
           this.dispatchDri(r.dri_params);
         })
         .catch((e) => {
@@ -53,6 +55,9 @@ export default {
     },
     dispatchBmr(params) {
       this.$store.dispatch('bmrParams/setAttributes', params);
+    },
+    dispatchPfc(params) {
+      this.$store.dispatch('pfcBalance/setAttributes', params);
     },
     dispatchDri(params) {
       this.$store.dispatch('referenceIntakes/setAttributes', params);

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -38,6 +38,7 @@ export default {
     this.setData();
   },
   methods: {
+    // BMRフォーム用のメソッド
     setData() {
       this.axios
         .get('/api/v1/mypage')
@@ -66,10 +67,13 @@ export default {
     updateBmrAndReference() {
       this.axios
         .patch('/api/v1/bmr', { user: this.$store.state.bmrParams.user })
-        .then((response) => {
-          console.log(response.status);
+        .then((res) => {
+          console.log(res.status);
 
-          this.$store.commit('bmrParams/updateBmr', response.data.bmr);
+          this.$store.commit('bmrParams/updateBmr', res.data.bmr);
+          this.dispatchPfc(res.data.pfc_params);
+
+          // TODO: genderまたはbirthの値に変更がある時のみ実行するよう
           this.updateReferenceIntake();
         })
         .catch((error) => {
@@ -90,12 +94,12 @@ export default {
     updateReferenceIntake() {
       this.axios
         .patch('/api/v1/users_dietary_reference_intake')
-        .then((response) => {
-          console.log(response.status);
+        .then((res) => {
+          console.log(res.status);
 
           this.$store.dispatch(
             'referenceIntakes/setAttributes',
-            response.data.data.attributes
+            res.data.data.attributes
           );
         })
         .catch((error) => {

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -39,9 +39,23 @@ export default {
   },
   methods: {
     setData() {
-      this.axios.get('/api/v1/bmr').then((response) => {
-        this.$store.dispatch('bmrParams/setAttributes', response.data);
-      });
+      this.axios.get('/api/v1/mypage')
+        .then((res) => {
+          console.log(res.status);
+
+          const r = res.data;
+          this.dispatchBmr(r.bmr_params);
+          this.dispatchDri(r.dri_params);
+        })
+        .catch((e) => {
+          console.log(e.response.status);
+        });
+    },
+    dispatchBmr(params) {
+      this.$store.dispatch('bmrParams/setAttributes', params);
+    },
+    dispatchDri(params) {
+      this.$store.dispatch('referenceIntakes/setAttributes', params);
     },
     // TODO: 要リファクタリング
     updateBmrAndReference() {

--- a/app/javascript/components/pages/TopPage.vue
+++ b/app/javascript/components/pages/TopPage.vue
@@ -10,7 +10,7 @@
     <div>
       <p>require login</p>
       <router-link to="/home">home</router-link>
-      <router-link to="/mypage">mypage</router-link>
+      <router-link to="/mypage">mypage（コントローラー改修済）</router-link>
     </div>
   </v-container>
 </template>

--- a/app/javascript/components/parts/BmrForm.vue
+++ b/app/javascript/components/parts/BmrForm.vue
@@ -106,16 +106,21 @@
             />
           </validation-provider>
           <div class="result">
-            <v-btn type="submit" color="base" outlined tile small>=</v-btn>
-            <span class="base--text result-text">
+            <v-btn type="submit" color="base" outlined tile small class="mt-1"
+              >=</v-btn
+            >
+            <div class="base--text result-text">
               基礎代謝量: <span class="text-h5 result-bmr">{{ bmr }}</span
-              >kcal
-            </span>
+              >kcal<br />
+              <!-- TODO: PFCの内訳は仮置き -->
+              <span class="text-body-2">
+                P: {{ amt.amtP }}g / F: {{ amt.amtF }}g / C: {{ amt.amtC }}g
+              </span>
+            </div>
           </div>
         </v-form>
       </validation-observer>
     </v-card>
-    <!-- TODO: 国立健康・栄養研究所の式に変更予定 -->
     <div class="caption">
       <p class="text-caption primary--text">
         BMRの算出には国立健康・栄養研究所の式を採用しています。
@@ -128,6 +133,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 export default {
   data() {
     return {
@@ -142,6 +149,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters('pfcBalance', ['amt']),
     // TODO: 要リファクタリング
     gender: {
       get() {
@@ -209,13 +217,14 @@ export default {
 }
 
 .result {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   margin-top: 10px;
 }
 
 .result-text {
   margin-left: 20px;
+  text-align: center;
 }
 
 .result-bmr {

--- a/app/javascript/components/parts/MyPageDriIndex.vue
+++ b/app/javascript/components/parts/MyPageDriIndex.vue
@@ -61,21 +61,6 @@ export default {
   computed: {
     ...mapGetters('referenceIntakes', ['vitamins', 'minerals']),
   },
-  mounted() {
-    this.setData();
-  },
-  methods: {
-    setData() {
-      this.axios
-        .get('/api/v1/users_dietary_reference_intake')
-        .then((response) => {
-          this.$store.dispatch(
-            'referenceIntakes/setAttributes',
-            response.data.data.attributes
-          );
-        });
-    },
-  },
 };
 </script>
 

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -5,6 +5,7 @@ import createPersistedState from 'vuex-persistedstate';
 import authUser from './modules/authUser';
 import bmrParams from './modules/bmrParams';
 import flashMessage from './modules/flashMessage';
+import pfcBalance from './modules/pfcBalance';
 import referenceIntakes from './modules/referenceIntakes';
 
 Vue.use(Vuex);
@@ -14,6 +15,7 @@ const store = new Vuex.Store({
     authUser,
     bmrParams,
     flashMessage,
+    pfcBalance,
     referenceIntakes,
   },
 

--- a/app/javascript/store/modules/pfcBalance.js
+++ b/app/javascript/store/modules/pfcBalance.js
@@ -1,0 +1,48 @@
+const state = {
+  pct: {
+    pctP: '',
+    pctF: '',
+    pctC: '',
+  },
+  amt: {
+    amtP: '',
+    amtF: '',
+    amtC: '',
+  },
+};
+
+const getters = {
+  pct: (state) =>
+    Object.keys(state.pct).forEach((key) => {
+      state.pct[key] *= 100;
+    }),
+  amt: (state) => state.amt,
+};
+
+const mutations = {
+  updatePct(state, value) {
+    state.pct.pctP = value.pct_p;
+    state.pct.pctF = value.pct_f;
+    state.pct.pctC = value.pct_c;
+  },
+  updateAmt(state, value) {
+    state.amt.amtP = value.amt_p;
+    state.amt.amtF = value.amt_f;
+    state.amt.amtC = value.amt_c;
+  },
+};
+
+const actions = {
+  setAttributes(context, attr) {
+    context.commit('updatePct', attr.pct);
+    context.commit('updateAmt', attr.amt);
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions,
+};

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,26 +54,34 @@ class User < ApplicationRecord
     end
   end
 
-  # TODO: コントローラーの整理後不要になるかも？
-  def set_attributes_for_bmr
+  def set_mypage_params
     {
-      gender: gender,
-      birth: birth,
-      height: height,
-      weight: weight,
-      bmr: bmr
-    }
-  end
-
-  def set_amount_pfc
-    {
-      protein: calc_amount_protein.floor,
-      fat: calc_amount_fat.floor,
-      carbohydrate: calc_amount_carbo.floor
+      bmr_params: set_attributes_for_bmr,
+      pfc_params: set_attributes_for_pfc,
+      dri_params: dietary_reference_intake
     }
   end
 
   private
+
+    def set_attributes_for_bmr
+      {
+        gender: gender,
+        birth: birth,
+        height: height,
+        weight: weight,
+        bmr: bmr
+      }
+    end
+
+    def set_attributes_for_pfc
+      { pct: { pct_p: percentage_protein,
+               pct_f: percentage_fat,
+               pct_c: percentage_carbohydrate },
+        amt: { amt_p: calc_amount_protein.floor,
+               amt_f: calc_amount_fat.floor,
+               amt_c: calc_amount_carbo.floor } }
+    end
 
     def calc_amount_protein
       bmr * percentage_protein / 4

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,15 @@ class User < ApplicationRecord
     }
   end
 
+  def set_attributes_for_pfc
+    { pct: { pct_p: percentage_protein,
+             pct_f: percentage_fat,
+             pct_c: percentage_carbohydrate },
+      amt: { amt_p: calc_amount_protein.floor,
+             amt_f: calc_amount_fat.floor,
+             amt_c: calc_amount_carbo.floor } }
+  end
+
   private
 
     def set_attributes_for_bmr
@@ -72,15 +81,6 @@ class User < ApplicationRecord
         weight: weight,
         bmr: bmr
       }
-    end
-
-    def set_attributes_for_pfc
-      { pct: { pct_p: percentage_protein,
-               pct_f: percentage_fat,
-               pct_c: percentage_carbohydrate },
-        amt: { amt_p: calc_amount_protein.floor,
-               amt_f: calc_amount_fat.floor,
-               amt_c: calc_amount_carbo.floor } }
     end
 
     def calc_amount_protein

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :registration, only: %i[create]
       resource :authentication, only: %i[create destroy]
-      resource :bmr, only: %i[show update]
-      resource :users_dietary_reference_intake, only: %i[show update]
+      resource :mypage, only: %i[show]
+      resource :bmr, only: %i[update]
+      resource :users_dietary_reference_intake, only: %i[update]
     end
   end
 
@@ -48,11 +49,10 @@ end
 #                   api_v1_registration POST   /api/v1/registration(.:format)                                                           api/v1/registrations#create {:format=>/json/}
 #                 api_v1_authentication DELETE /api/v1/authentication(.:format)                                                         api/v1/authentications#destroy {:format=>/json/}
 #                                       POST   /api/v1/authentication(.:format)                                                         api/v1/authentications#create {:format=>/json/}
-#                            api_v1_bmr GET    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#show {:format=>/json/}
-#                                       PATCH  /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
+#                         api_v1_mypage GET    /api/v1/mypage(.:format)                                                                 api/v1/mypages#show {:format=>/json/}
+#                            api_v1_bmr PATCH  /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
 #                                       PUT    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
-# api_v1_users_dietary_reference_intake GET    /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#show {:format=>/json/}
-#                                       PATCH  /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}
+# api_v1_users_dietary_reference_intake PATCH  /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}
 #                                       PUT    /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}
 #                                       GET    /*path(.:format)                                                                         top#index
 #         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create


### PR DESCRIPTION
## 概要
マイページで必要な情報を取得するために、「BMR設定用の情報を取得する」「栄養摂取基準を取得する」
「PFCバランス情報を取得する」の3つのリクエストをそれぞれ別のコントローラーに投げていたものを、
新たに`mypages_controller`を作成し1リクエストにまとめた。
また、PFCバランス用のストアを新規に作成し、便宜的にBMRフォームのコンポーネント内に
PFCのグラ無数の値を表示するように変更した。

<br />


## チェックリスト
- [x] mypages_controllerの作成
- [x] 既存の処理の移植
- [x] 不要になったアクションの削除
- [x] ルーティングの再定義
- [x] フロントのメソッドの修正
- [x] 各ストアへのディスパッチの修正
- [x] リントチェック
- [x] 動作確認

<br />

closes #42 
