### PR TITLE
食事内容を提案するrakeタスク を作成#23

### DIFF
--- a/app/controllers/admin/suggestions_controller.rb
+++ b/app/controllers/admin/suggestions_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Admin
+  class Admin::SuggestionsController < Admin::BaseController
+    def index
+      @q = Suggestion.ransack(params[:q])
+      @suggestions = @q.result.page(params[:page])
+    end
+  end
+end

--- a/app/controllers/admin/suggestions_controller.rb
+++ b/app/controllers/admin/suggestions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class Admin::SuggestionsController < Admin::BaseController
+  class SuggestionsController < Admin::BaseController
     def index
       @q = Suggestion.ransack(params[:q])
       @suggestions = @q.result.page(params[:page])

--- a/app/javascript/components/pages/TopPage.vue
+++ b/app/javascript/components/pages/TopPage.vue
@@ -10,6 +10,7 @@
     <div>
       <p>実装済みリスト</p>
       <p>食品カテゴリー・食品</p>
+      <p>rakeタスクを作成</p>
       <p>require login</p>
       <router-link to="/home">home</router-link>
       <router-link to="/mypage">mypage（コントローラー改修済）</router-link>

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -3,6 +3,7 @@
 class Food < ApplicationRecord
   # Associations
   belongs_to :food_category
+  has_many :suggestions, dependent: :destroy
 
   # Validations
   with_options presence: true do

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -5,6 +5,14 @@ class Food < ApplicationRecord
   belongs_to :food_category
   has_many :suggestions, dependent: :destroy
 
+  # Scopes
+  scope :prio_h, -> { where(priority: 15) }
+  scope :prio_m, -> { where(priority: 10) }
+  scope :prio_r, -> { where(priority: 5) }
+  scope :prio_rm, -> { where(priority: 5..10) }
+  scope :maindish, -> { where(food_category_id: [10, 11]) }
+  scope :sidedish, -> { where(food_category_id: 1..9) }
+
   # Validations
   with_options presence: true do
     validates :name, length: { maximum: 30 }

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Suggestion < ApplicationRecord
   # Associations
   belongs_to :user

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,0 +1,27 @@
+class Suggestion < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float            default(1.0), not null
+#  expires_at  :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -2,6 +2,15 @@ class Suggestion < ApplicationRecord
   # Associations
   belongs_to :user
   belongs_to :food
+
+  # Validations
+  with_options presence: true do
+    validates :amount
+    validates :target_date
+    validates :expires_at
+  end
+
+  validates :user_id, uniqueness: { scope: [:food_id, :target_date] }
 end
 
 # == Schema Information

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,4 +1,7 @@
 class Suggestion < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :food
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
 
   # Associations
   belongs_to :dietary_reference_intake
+  has_many :suggestions, dependent: :destroy
+  has_many :suggested_foods, through: :suggestions, source: :food
 
   # Enums
   enum gender: { female: 0, male: 10 }

--- a/app/views/admin/suggestions/index.html.erb
+++ b/app/views/admin/suggestions/index.html.erb
@@ -1,0 +1,38 @@
+<div id="admin-contents">
+  <h3>提案一覧</h3>
+
+  <%= search_form_for @q, url: admin_suggestions_path do |f| %>
+    <div class="admin-search-group">
+      <div class="admin-search-form">
+        <%= f.label :user_id_eq, 'ユーザーID', class: "admin-form-label" %>
+        <%= f.number_field :user_id_eq, class: "admin-form-number" %>
+      </div>
+      <%= f.submit %>
+    </div>
+  <% end %> 
+  <table class="admin-table">
+    <t-head>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:id) %></th>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:user_id) %></th>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:food_id) %></th>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:target_date) %></th>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:expires_at) %></th>
+      <th class="admin-t-head"><%= Suggestion.human_attribute_name(:created_at) %></th>
+    </t-head>
+    <t-body>
+      <% @suggestions.each do |sgt| %>
+        <tr class="admin-t-row">
+          <td class="admin-t-data"><%= sgt.id %></td>
+          <td class="admin-t-data"><%= link_to sgt.user_id, admin_user_path(sgt.user_id) %></td>
+          <td class="admin-t-data"><%= link_to sgt.food_id, admin_food_path(sgt.food_id) %></td>
+          <td class="admin-t-data"><%= l sgt.target_date, format: :default %></td>
+          <td class="admin-t-data"><%= l sgt.expires_at, format: :default %></td>
+          <td class="admin-t-data"><%= l sgt.created_at, format: :default %></td>
+        </tr>
+      <% end %>
+    </t-body>
+  </table>
+  <div class="admin-pagenate" >
+    <%= paginate @suggestions %>
+  </div>
+</div>

--- a/config/custom_log_formatter.rb
+++ b/config/custom_log_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Logger
+  class CustomLogFormatter < Formatter
+    def call(severity, time, _progname, msg)
+      "  [Level] #{severity} \n" \
+        "   [Time] #{time} \n" \
+        "[Message] #{msg} \n\n\n"
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../custom_log_formatter'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -54,6 +56,9 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+
+  # config.logger = Logger.new STDOUT
+  config.log_formatter = ::Logger::CustomLogFormatter.new
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -5,6 +5,7 @@ ja:
       dietary_reference_intake: "食事摂取基準"
       food_category: "食品カテゴリー"
       food: "食品"
+      suggestion: "提案"
     attributes:
       user:
         id: "id"
@@ -112,6 +113,13 @@ ja:
         vitamin_e: "ビタミンE"
         vitamin_k: "ビタミンK"
         zinc: "亜鉛"
+        created_at: "登録日時"
+        updated_at: "更新日時"
+      suggestion:
+        user_id: "ユーザーID"
+        food_id: "食品ID"
+        target_date: "対象日"
+        expires_at: "有効期限"
         created_at: "登録日時"
         updated_at: "更新日時"
   enums:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :dietary_reference_intakes, only: %i[index show destroy]
     resources :food_categories, only: %i[index edit update destroy]
     resources :foods, only: %i[index show edit update destroy]
+    resources :suggestions, only: %i[index]
   end
 
   namespace :api, format: 'json' do
@@ -59,6 +60,7 @@ end
 #                                       PATCH  /admin/foods/:id(.:format)                                                               admin/foods#update
 #                                       PUT    /admin/foods/:id(.:format)                                                               admin/foods#update
 #                                       DELETE /admin/foods/:id(.:format)                                                               admin/foods#destroy
+#                     admin_suggestions GET    /admin/suggestions(.:format)                                                             admin/suggestions#index
 #                   api_v1_registration POST   /api/v1/registration(.:format)                                                           api/v1/registrations#create {:format=>/json/}
 #                 api_v1_authentication DELETE /api/v1/authentication(.:format)                                                         api/v1/authentications#destroy {:format=>/json/}
 #                                       POST   /api/v1/authentication(.:format)                                                         api/v1/authentications#create {:format=>/json/}

--- a/db/migrate/20211008111733_create_suggestions.rb
+++ b/db/migrate/20211008111733_create_suggestions.rb
@@ -1,0 +1,15 @@
+class CreateSuggestions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :suggestions do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :food, foreign_key: true, null: false
+      t.float :amount, null: false, default: 1.0
+      t.date :target_date, null: false
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :suggestions, [:user_id, :food_id, :target_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_071354) do
+ActiveRecord::Schema.define(version: 2021_10_08_111733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,19 @@ ActiveRecord::Schema.define(version: 2021_10_07_071354) do
     t.index ["food_category_id"], name: "index_foods_on_food_category_id"
   end
 
+  create_table "suggestions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "food_id", null: false
+    t.float "amount", default: 1.0, null: false
+    t.date "target_date", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["food_id"], name: "index_suggestions_on_food_id"
+    t.index ["user_id", "food_id", "target_date"], name: "index_suggestions_on_user_id_and_food_id_and_target_date", unique: true
+    t.index ["user_id"], name: "index_suggestions_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", default: "noname", null: false
     t.string "email", default: "address@example.com", null: false
@@ -133,5 +146,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_071354) do
   end
 
   add_foreign_key "foods", "food_categories"
+  add_foreign_key "suggestions", "foods"
+  add_foreign_key "suggestions", "users"
   add_foreign_key "users", "dietary_reference_intakes"
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,4 +1,9 @@
-namespace :suggestion do
+namespace :scheduler do
+  desc "動作確認用"
+  task test_scheduler: :environment do
+    puts "Scheduler test is works."
+  end
+
   desc "期限切れのsuggestionを削除"
   task destroy_expied_suggestions: :environment do
     User.find_each do |user|
@@ -27,14 +32,15 @@ namespace :suggestion do
             item = user.suggestions.new(
               food_id: m.id,
               amount: m.reference_amount,
-              target_date: "",
+              # target_date: "",
+              target_date: Time.current.ago(1.day),
               # target_date: Time.zone.today,
               expires_at: Time.current.end_of_day
             )
   
             item.save!
           end
-        end        
+        end
       rescue => exception
         Rails.logger.warn "User#{user.id}: Failed to save the suggestion. Cause...'#{exception}'"
       end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :scheduler do
   desc "動作確認用"
   task test_scheduler: :environment do
@@ -37,12 +39,12 @@ namespace :scheduler do
               # target_date: Time.zone.today,
               expires_at: Time.current.end_of_day
             )
-  
+
             item.save!
           end
         end
-      rescue => exception
-        Rails.logger.warn "User#{user.id}: Failed to save the suggestion. Cause...'#{exception}'"
+      rescue StandardError => e
+        Rails.logger.warn "User#{user.id}: Failed to save the suggestion. Cause...'#{e}'"
       end
     end
   end

--- a/lib/tasks/suggestion.rake
+++ b/lib/tasks/suggestion.rake
@@ -1,0 +1,89 @@
+namespace :suggestion do
+  desc "期限切れのsuggestionを削除"
+  task destroy_expied_suggestions: :environment do
+    User.find_each do |user|
+      Suggestion.transaction do
+        user.suggestions.where("expires_at < ?", Time.zone.today).each(&:destroy!)
+      end
+    end
+  end
+
+  desc "ユーザーごとに当日の食事内容を新規作成"
+  task create_suggestion: :environment do
+    User.find_each do |user|
+      meal_menus = []
+
+      # 食材を上限4種類にしぼり提案を作成する場合
+      regular = Food.prio_h.order("RANDOM()").limit(1)
+      main = Food.prio_m.maindish.order("RANDOM()").limit(1)
+      side = Food.prio_rm.sidedish.order("RANDOM()").limit(2)
+
+      meal_menus.concat(regular, main, side)
+
+      # 確定したメニューの内容をSuggestionのインスタンスとして保存
+      begin
+        Suggestion.transaction do
+          meal_menus.each do |m|
+            item = user.suggestions.new(
+              food_id: m.id,
+              amount: m.reference_amount,
+              target_date: "",
+              # target_date: Time.zone.today,
+              expires_at: Time.current.end_of_day
+            )
+  
+            item.save!
+          end
+        end        
+      rescue => exception
+        Rails.logger.warn "User#{user.id}: Failed to save the suggestion. Cause...'#{exception}'"
+      end
+    end
+  end
+end
+
+# # 上限なくBMRを満たす分の提案を作成する場合
+# # 食品の配列から合計カロリーを算出
+# def sum_calories(foods)
+#   foods.inject(0) do |sum, food|
+#     sum + food.calorie * food.reference_amount
+#   end
+# end
+
+# User.find_each do |user|
+#   meal_menus = []
+
+#   # ・主菜・主食をそれぞれ1つずつ追加
+#   regular = Food.h_prio
+#   main = Food.m_prio.maindish.order("RANDOM()").limit(1)
+#   staple = Food.m_prio.staple_food.order("RANDOM()").limit(1)
+
+#   meal_menus.concat(regular, main, staple)
+
+#   # 合計カロリーがBMRに達するまで副菜を追加
+#   # TODO: 無理矢理な計数ループ、要リファクタリング
+#   bmr = user.bmr
+#   loop = 0
+#   while !@over_bmr && loop <= 50
+#     # 重複を避けてサイドメニューを1つずつ取得
+#     side = Food.where.not(id: meal_menus.map(&:id)).rm_prio.sidedish.order("RANDOM()").limit(1)
+#     meal_menus.concat(side)
+
+#     @over_bmr = sum_calories(meal_menus) > bmr
+#     loop += 1
+#   end
+
+#   # 確定したメニューの内容をSuggestionのインスタンスとして保存
+#   Suggestion.transaction do
+#     meal_menus.each do |m|
+#       item = user.suggestions.new(
+#         food_id: m.id,
+#         amount: m.reference_amount,
+#         target_date: Time.zone.today,
+#         expires_at: Time.current.end_of_day
+#       )
+
+#       item.save!
+#     end
+#   end
+# end

--- a/spec/factories/suggestions.rb
+++ b/spec/factories/suggestions.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :suggestion do
-    
   end
 end
 

--- a/spec/factories/suggestions.rb
+++ b/spec/factories/suggestions.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :suggestion do
+    
+  end
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float            default(1.0), not null
+#  expires_at  :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/models/suggestion_spec.rb
+++ b/spec/models/suggestion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Suggestion, type: :model do

--- a/spec/models/suggestion_spec.rb
+++ b/spec/models/suggestion_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Suggestion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float            default(1.0), not null
+#  expires_at  :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#


### PR DESCRIPTION
# 概要
各ユーザーごとにその日の食事内容の提案を作成するrakeタスクを作成した。
現時点で考えられる方法として以下の2パターンがあるが、1つ目の BMRを
基準とした場合食事の量が非常に多くなってしまうため、一旦２番目の方法を
とることにする。

- 食材数に制限は設けずBMRを満たすことを条件とする
- 食材の個数を制限しその中でランダムに生成する

なお、Herokuではcronは使用できないため、タスクのスケジューリングに
`whenever`は使用せず、`heroku scheduler`を使用することになる、
そのためスケジュールかのテストはまだ行っておらず、次のLINE通知機能を
作成する際に同時に行う予定である。

<br />


## チェックリスト
- [x] Suggestionsモデルの作成
- [x] バリデーションの作成
- [x] アソシエーションの定義
- [x] rakeタスクの作成
- [x] リントチェック
- [x] 動作確認

<br />

closes #23 
