### PR TITLE
食事提案内容参照機能を作成#47

### DIFF
--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     class SuggestionsController < Api::V1::BaseController

--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -6,7 +6,7 @@ module Api
         amt_pfc = current_user.set_attributes_for_pfc[:amt]
 
         total = get_intake_total(foods)
-        achv = get_achievement(total.attributes,
+        achv = get_achievement(total,
                                current_user.bmr,
                                current_user.dietary_reference_intake,
                                amt_pfc)
@@ -17,7 +17,7 @@ module Api
       private
 
         def get_intake_total(foods)
-          total = TotalNutrition.new
+          total = NutritionTotal.new
           total.calc_intake_total(foods)
         end
 

--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class SuggestionsController < Api::V1::BaseController
+      def show
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -2,7 +2,29 @@ module Api
   module V1
     class SuggestionsController < Api::V1::BaseController
       def show
+        foods = current_user.suggested_foods
+        amt_pfc = current_user.set_attributes_for_pfc[:amt]
+
+        total = get_intake_total(foods)
+        achv = get_achievement(total.attributes,
+                               current_user.bmr,
+                               current_user.dietary_reference_intake,
+                               amt_pfc)
+
+        render json: { meals: foods, total: total, achv: achv }
       end
+
+      private
+
+        def get_intake_total(foods)
+          total = TotalNutrition.new
+          total.calc_intake_total(foods)
+        end
+
+        def get_achievement(total, bmr, dri, pfc)
+          achv = IntakeAchievement.new
+          achv.calc_intake_achievement(total, bmr, dri, pfc)
+        end
     end
   end
 end

--- a/app/javascript/components/pages/MealSuggestionPage.vue
+++ b/app/javascript/components/pages/MealSuggestionPage.vue
@@ -1,0 +1,6 @@
+<template>
+</template>
+
+<script>
+export default {};
+</script>

--- a/app/javascript/components/pages/MealSuggestionPage.vue
+++ b/app/javascript/components/pages/MealSuggestionPage.vue
@@ -1,6 +1,130 @@
 <template>
+  <v-container class="container">
+    <v-row class="suggestion-row">
+      <v-col cols="12" md="6" class="pa-0">
+        <div class="suggestion-item">
+          <div class="base--text suggestion-items-title">
+            <span class="suggestion-items-title-text">Today's meal</span>
+          </div>
+          <div class="meal-menus">
+            <template
+              v-for="f in suggestions"
+            >
+              <v-sheet :key="f.id" color="base" class="foods-card">
+                <v-card
+                  flat
+                  tile
+                  color="primary"
+                  height="60"
+                  width="130"
+                  class="foods-card-contents"
+                >
+                  <v-card-text class="pa-0 text-caption text-center base--text">
+                    <div class="font-weight-medium">
+                      {{ f.name }} {{ f.subname }}
+                    </div>
+                    <div>
+                      {{ f.reference_amount * 100 }}g
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-sheet>
+            </template>
+          </div>
+        </div>
+      </v-col>
+      <v-col cols="12" md="6" class="pa-0">
+        <div>
+          <nutrients-achievement />
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
-export default {};
+import NutrientsAchievement from '../parts/NutrientsAchievement';
+
+export default {
+  components: {
+    NutrientsAchievement
+  },
+  data() {
+    return {
+      suggestions: {}
+    };
+  },
+  mounted() {
+    this.setSuggestions();
+  },
+  methods: {
+    setSuggestions() {
+      this.axios
+        .get('/api/v1/suggestion')
+        .then(res => {
+          console.log(res.status);
+          const r = res.data;
+
+          this.suggestions = r.meals;
+          this.$store.dispatch(
+            'nutrientsAchievements/setAttributes',
+            {
+              totals: r.total,
+              achvs: r.achv,
+            }
+          );
+        })
+        .catch(e => {
+          console.error(e);
+        });
+    }
+  }
+};
 </script>
+
+<style scoped>
+.container {
+  margin: 0;
+  padding: 0;
+}
+
+.suggestion-row {
+  background-color: #5a7899;
+  margin: 30px 20px;
+}
+
+.suggestion-item {
+  margin-bottom: 40px;
+}
+
+.suggestion-items-title {
+  border-bottom: 1px solid #f5f5f6;
+  height: 48px;
+  margin-bottom: 15px;
+}
+
+.meal-menus {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.foods-card {
+  border: 1px solid #f5f5f6;
+}
+
+.foods-card-contents {
+  padding: 8px 8px;
+}
+
+.tabs {
+  border-right: 1px solid #f5f5f6;
+  border-bottom: 1px solid #f5f5f6;
+  border-top: 1px solid #f5f5f6;
+}
+
+.tabs-end {
+  border-bottom: 1px solid #f5f5f6;
+  border-top: 1px solid #f5f5f6;
+}
+</style>

--- a/app/javascript/components/pages/MealSuggestionPage.vue
+++ b/app/javascript/components/pages/MealSuggestionPage.vue
@@ -7,9 +7,7 @@
             <span class="suggestion-items-title-text">Today's meal</span>
           </div>
           <div class="meal-menus">
-            <template
-              v-for="f in suggestions"
-            >
+            <template v-for="f in suggestions">
               <v-sheet :key="f.id" color="base" class="foods-card">
                 <v-card
                   flat
@@ -23,9 +21,7 @@
                     <div class="font-weight-medium">
                       {{ f.name }} {{ f.subname }}
                     </div>
-                    <div>
-                      {{ f.reference_amount * 100 }}g
-                    </div>
+                    <div>{{ f.reference_amount * 100 }}g</div>
                   </v-card-text>
                 </v-card>
               </v-sheet>
@@ -47,11 +43,11 @@ import NutrientsAchievement from '../parts/NutrientsAchievement';
 
 export default {
   components: {
-    NutrientsAchievement
+    NutrientsAchievement,
   },
   data() {
     return {
-      suggestions: {}
+      suggestions: {},
     };
   },
   mounted() {
@@ -61,24 +57,21 @@ export default {
     setSuggestions() {
       this.axios
         .get('/api/v1/suggestion')
-        .then(res => {
+        .then((res) => {
           console.log(res.status);
           const r = res.data;
 
           this.suggestions = r.meals;
-          this.$store.dispatch(
-            'nutrientsAchievements/setAttributes',
-            {
-              totals: r.total,
-              achvs: r.achv,
-            }
-          );
+          this.$store.dispatch('nutrientsAchievements/setAttributes', {
+            totals: r.total,
+            achvs: r.achv,
+          });
         })
-        .catch(e => {
+        .catch((e) => {
           console.error(e);
         });
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/app/javascript/components/parts/BmrForm.vue
+++ b/app/javascript/components/parts/BmrForm.vue
@@ -114,7 +114,8 @@
               >kcal<br />
               <!-- TODO: PFCの内訳は仮置き -->
               <span class="text-body-2">
-                P: {{ amt.protein }}g / F: {{ amt.fat }}g / C: {{ amt.carbohydrate }}g
+                P: {{ amt.protein }}g / F: {{ amt.fat }}g / C:
+                {{ amt.carbohydrate }}g
               </span>
             </div>
           </div>

--- a/app/javascript/components/parts/BmrForm.vue
+++ b/app/javascript/components/parts/BmrForm.vue
@@ -114,7 +114,7 @@
               >kcal<br />
               <!-- TODO: PFCの内訳は仮置き -->
               <span class="text-body-2">
-                P: {{ amt.amtP }}g / F: {{ amt.amtF }}g / C: {{ amt.amtC }}g
+                P: {{ amt.protein }}g / F: {{ amt.fat }}g / C: {{ amt.carbohydrate }}g
               </span>
             </div>
           </div>

--- a/app/javascript/components/parts/FooterMenuItemsAfterLogin.vue
+++ b/app/javascript/components/parts/FooterMenuItemsAfterLogin.vue
@@ -34,6 +34,9 @@
           <v-list-item to="/mypage">
             <v-list-item-title>mypage</v-list-item-title>
           </v-list-item>
+          <v-list-item to="/suggestion">
+            <v-list-item-title>today's meal</v-list-item-title>
+          </v-list-item>
         </v-list-item-group>
       </v-list>
     </v-menu>

--- a/app/javascript/components/parts/NutrientsAchievement.vue
+++ b/app/javascript/components/parts/NutrientsAchievement.vue
@@ -5,9 +5,7 @@
     <v-tab class="tabs-end">Mineral</v-tab>
 
     <v-tab-item class="tab-item">
-      <template
-        v-for="m in macro"
-      >
+      <template v-for="m in macro">
         <v-sheet :key="m.key" color="base" class="nutrients-card">
           <v-card
             color="primary"
@@ -19,17 +17,21 @@
           >
             <v-card-text class="pa-0 text-caption text-left base--text">
               <div class="font-weight-medium">{{ m.label }}</div>
-              <div>Total:<span class="text-body-2">{{ m.total }}</span>{{ m.unit }}</div>
-              <div>Achv:<span class="text-body-2">{{ m.achv }}</span>%</div>
+              <div>
+                Total:<span class="text-body-2">{{ m.total }}</span
+                >{{ m.unit }}
+              </div>
+              <div>
+                Achv:<span class="text-body-2">{{ m.achv }}</span
+                >%
+              </div>
             </v-card-text>
           </v-card>
         </v-sheet>
       </template>
     </v-tab-item>
     <v-tab-item class="tab-item">
-      <template
-        v-for="v in vitamins"
-      >
+      <template v-for="v in vitamins">
         <v-sheet :key="v.key" class="nutrients-card">
           <v-card
             color="primary"
@@ -41,17 +43,21 @@
           >
             <v-card-text class="pa-0 text-caption text-left base--text">
               <div class="font-weight-medium">{{ v.label }}</div>
-              <div>Total:<span class="text-body-2">{{ v.total }}</span>{{ v.unit }}</div>
-              <div>Achv:<span class="text-body-2">{{ v.achv }}</span>%</div>
+              <div>
+                Total:<span class="text-body-2">{{ v.total }}</span
+                >{{ v.unit }}
+              </div>
+              <div>
+                Achv:<span class="text-body-2">{{ v.achv }}</span
+                >%
+              </div>
             </v-card-text>
           </v-card>
         </v-sheet>
       </template>
     </v-tab-item>
     <v-tab-item class="tab-item">
-      <template
-        v-for="m in minerals"
-      >
+      <template v-for="m in minerals">
         <v-sheet :key="m.key" class="nutrients-card">
           <v-card
             color="primary"
@@ -63,8 +69,14 @@
           >
             <v-card-text class="pa-0 text-caption text-left base--text">
               <div class="font-weight-medium">{{ m.label }}</div>
-              <div>Total:<span class="text-body-2">{{ m.total }}</span>{{ m.unit }}</div>
-              <div>Achv:<span class="text-body-2">{{ m.achv }}</span>%</div>
+              <div>
+                Total:<span class="text-body-2">{{ m.total }}</span
+                >{{ m.unit }}
+              </div>
+              <div>
+                Achv:<span class="text-body-2">{{ m.achv }}</span
+                >%
+              </div>
             </v-card-text>
           </v-card>
         </v-sheet>
@@ -78,12 +90,8 @@ import { mapGetters } from 'vuex';
 
 export default {
   computed: {
-    ...mapGetters('nutrientsAchievements', [
-      'macro',
-      'vitamins',
-      'minerals'
-    ])
-  }
+    ...mapGetters('nutrientsAchievements', ['macro', 'vitamins', 'minerals']),
+  },
 };
 </script>
 

--- a/app/javascript/components/parts/NutrientsAchievement.vue
+++ b/app/javascript/components/parts/NutrientsAchievement.vue
@@ -1,0 +1,116 @@
+<template>
+  <v-tabs background-color="primary" color="base" dark center-active grow>
+    <v-tab class="tabs">Macro</v-tab>
+    <v-tab class="tabs">Vitamin</v-tab>
+    <v-tab class="tabs-end">Mineral</v-tab>
+
+    <v-tab-item class="tab-item">
+      <template
+        v-for="m in macro"
+      >
+        <v-sheet :key="m.key" color="base" class="nutrients-card">
+          <v-card
+            color="primary"
+            flat
+            tile
+            height="80"
+            width="130"
+            class="nutrients-card-contents"
+          >
+            <v-card-text class="pa-0 text-caption text-left base--text">
+              <div class="font-weight-medium">{{ m.label }}</div>
+              <div>Total:<span class="text-body-2">{{ m.total }}</span>{{ m.unit }}</div>
+              <div>Achv:<span class="text-body-2">{{ m.achv }}</span>%</div>
+            </v-card-text>
+          </v-card>
+        </v-sheet>
+      </template>
+    </v-tab-item>
+    <v-tab-item class="tab-item">
+      <template
+        v-for="v in vitamins"
+      >
+        <v-sheet :key="v.key" class="nutrients-card">
+          <v-card
+            color="primary"
+            flat
+            tile
+            height="80"
+            width="130"
+            class="nutrients-card-contents"
+          >
+            <v-card-text class="pa-0 text-caption text-left base--text">
+              <div class="font-weight-medium">{{ v.label }}</div>
+              <div>Total:<span class="text-body-2">{{ v.total }}</span>{{ v.unit }}</div>
+              <div>Achv:<span class="text-body-2">{{ v.achv }}</span>%</div>
+            </v-card-text>
+          </v-card>
+        </v-sheet>
+      </template>
+    </v-tab-item>
+    <v-tab-item class="tab-item">
+      <template
+        v-for="m in minerals"
+      >
+        <v-sheet :key="m.key" class="nutrients-card">
+          <v-card
+            color="primary"
+            flat
+            tile
+            height="80"
+            width="130"
+            class="nutrients-card-contents"
+          >
+            <v-card-text class="pa-0 text-caption text-left base--text">
+              <div class="font-weight-medium">{{ m.label }}</div>
+              <div>Total:<span class="text-body-2">{{ m.total }}</span>{{ m.unit }}</div>
+              <div>Achv:<span class="text-body-2">{{ m.achv }}</span>%</div>
+            </v-card-text>
+          </v-card>
+        </v-sheet>
+      </template>
+    </v-tab-item>
+  </v-tabs>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  computed: {
+    ...mapGetters('nutrientsAchievements', [
+      'macro',
+      'vitamins',
+      'minerals'
+    ])
+  }
+};
+</script>
+
+<style scoped>
+.nutrients-card {
+  border: 1px solid #f5f5f6;
+}
+
+.nutrients-card-contents {
+  padding: 8px 8px;
+}
+
+.tabs {
+  border-right: 1px solid #f5f5f6;
+  border-top: 1px solid #f5f5f6;
+  border-bottom: 1px solid #f5f5f6;
+}
+
+.tabs-end {
+  border-top: 1px solid #f5f5f6;
+  border-bottom: 1px solid #f5f5f6;
+}
+
+.tab-item {
+  background-color: #5a7899;
+  padding: 20px 15px 40px 15px;
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -5,6 +5,7 @@ import store from '../store/index';
 import TopPage from '../components/pages/TopPage';
 import RegisterPage from '../components/pages/RegisterPage';
 import LoginPage from '../components/pages/LoginPage';
+import MealSuggestionPage from '../components/pages/MealSuggestionPage';
 import HomePage from '../components/pages/HomePage';
 import MyPage from '../components/pages/MyPage';
 import NotFound from '../components/pages/NotFound';
@@ -43,6 +44,11 @@ const router = new VueRouter({
       path: '/mypage',
       component: MyPage,
       name: 'MyPage',
+    },
+    {
+      path: '/suggestion',
+      component: MealSuggestionPage,
+      name: 'MealSuggestionPage',
     },
     // 404 not found
     {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -5,6 +5,7 @@ import createPersistedState from 'vuex-persistedstate';
 import authUser from './modules/authUser';
 import bmrParams from './modules/bmrParams';
 import flashMessage from './modules/flashMessage';
+import nutrientsAchievements from './modules/nutrientsAchievements';
 import pfcBalance from './modules/pfcBalance';
 import referenceIntakes from './modules/referenceIntakes';
 
@@ -15,6 +16,7 @@ const store = new Vuex.Store({
     authUser,
     bmrParams,
     flashMessage,
+    nutrientsAchievements,
     pfcBalance,
     referenceIntakes,
   },

--- a/app/javascript/store/modules/nutrientsAchievements.js
+++ b/app/javascript/store/modules/nutrientsAchievements.js
@@ -1,0 +1,80 @@
+const state = {
+  macro: {
+    calorie: { label: 'カロリー', total: '', unit: 'kcal', achv: '' },
+    protein: { label: 'タンパク質', total: '', unit: 'g', achv: '' },
+    fat: { label: '脂質', total: '', unit: 'g', achv: '' },
+    carbohydrate: { label: '炭水化物', total: '', unit: 'g', achv: '' }
+  },
+  vitamins: {
+    vitamin_a: { label: 'ビタミンA', total: '', unit: 'μgRAE', achv: '' },
+    vitamin_d: { label: 'ビタミンD', total: '', unit: 'μg', achv: '' },
+    vitamin_e: { label: 'ビタミンE', total: '', unit: 'mg', achv: '' },
+    vitamin_k: { label: 'ビタミンK', total: '', unit: 'μg', achv: '' },
+    vitamin_b1: { label: 'ビタミンB1', total: '', unit: 'mg', achv: '' },
+    vitamin_b2: { label: 'ビタミンB2', total: '', unit: 'mg', achv: '' },
+    niacin: { label: 'ナイアシン', total: '', unit: 'mgNE', achv: '' },
+    vitamin_b6: { label: 'ビタミンB6', total: '', unit: 'mg', achv: '' },
+    vitamin_b12: { label: 'ビタミンB12', total: '', unit: 'μg', achv: '' },
+    folate: { label: '葉酸', total: '', unit: 'μg', achv: '' },
+    pantothenic_acid: { label: 'パントテン酸', total: '', unit: 'mg', achv: '' },
+    biotin: { label: 'ビオチン', total: '', unit: 'μg', achv: '' },
+    vitamin_c: { label: 'ビタミンC', total: '', unit: 'mg', achv: '' }
+  },
+  minerals: {
+    potassium: { label: 'カリウム', total: '', unit: 'mg', achv: '' },
+    calcium: { label: 'カルシウム', total: '', unit: 'mg', achv: '' },
+    magnesium: { label: 'マグネシウム', total: '', unit: 'mg', achv: '' },
+    phosphorus: { label: 'リン', total: '', unit: 'mg', achv: '' },
+    iron: { label: '鉄', total: '', unit: 'mg', achv: '' },
+    zinc: { label: '亜鉛', total: '', unit: 'mg', achv: '' },
+    copper: { label: '銅', total: '', unit: 'mg', achv: '' },
+    manganese: { label: 'マンガン', total: '', unit: 'mg', achv: '' },
+    iodine: { label: 'ヨウ素', total: '', unit: 'μg', achv: '' },
+    selenium: { label: 'セレン', total: '', unit: 'μg', achv: '' },
+    chromium: { label: 'クロム', total: '', unit: 'μg', achv: '' },
+    molybdenum: { label: 'モリブデン', total: '', unit: 'μg', achv: '' }
+  }
+};
+
+const getters = {
+  macro: state => state.macro,
+  vitamins: state => state.vitamins,
+  minerals: state => state.minerals
+};
+
+const mutations = {
+  setMacro(state, { total, achv }) {
+    Object.keys(state.macro).forEach(key => {
+      state.macro[key].total = total[key];
+      state.macro[key].achv = Math.trunc(achv[key] * 100);
+    });
+  },
+  setVitamins(state, { total, achv }) {
+    Object.keys(state.vitamins).forEach(key => {
+      state.vitamins[key].total = total[key];
+      state.vitamins[key].achv = Math.trunc(achv[key] * 100);
+    });
+  },
+  setMinerals(state, { total, achv }) {
+    Object.keys(state.minerals).forEach(key => {
+      state.minerals[key].total = total[key];
+      state.minerals[key].achv = Math.trunc(achv[key] * 100);
+    });
+  }
+};
+
+const actions = {
+  setAttributes(context, { totals, achvs }) {
+    context.commit('setMacro', { total: totals, achv: achvs });
+    context.commit('setVitamins', { total: totals, achv: achvs });
+    context.commit('setMinerals', { total: totals, achv: achvs });
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+};

--- a/app/javascript/store/modules/nutrientsAchievements.js
+++ b/app/javascript/store/modules/nutrientsAchievements.js
@@ -3,7 +3,7 @@ const state = {
     calorie: { label: 'カロリー', total: '', unit: 'kcal', achv: '' },
     protein: { label: 'タンパク質', total: '', unit: 'g', achv: '' },
     fat: { label: '脂質', total: '', unit: 'g', achv: '' },
-    carbohydrate: { label: '炭水化物', total: '', unit: 'g', achv: '' }
+    carbohydrate: { label: '炭水化物', total: '', unit: 'g', achv: '' },
   },
   vitamins: {
     vitamin_a: { label: 'ビタミンA', total: '', unit: 'μgRAE', achv: '' },
@@ -16,9 +16,14 @@ const state = {
     vitamin_b6: { label: 'ビタミンB6', total: '', unit: 'mg', achv: '' },
     vitamin_b12: { label: 'ビタミンB12', total: '', unit: 'μg', achv: '' },
     folate: { label: '葉酸', total: '', unit: 'μg', achv: '' },
-    pantothenic_acid: { label: 'パントテン酸', total: '', unit: 'mg', achv: '' },
+    pantothenic_acid: {
+      label: 'パントテン酸',
+      total: '',
+      unit: 'mg',
+      achv: '',
+    },
     biotin: { label: 'ビオチン', total: '', unit: 'μg', achv: '' },
-    vitamin_c: { label: 'ビタミンC', total: '', unit: 'mg', achv: '' }
+    vitamin_c: { label: 'ビタミンC', total: '', unit: 'mg', achv: '' },
   },
   minerals: {
     potassium: { label: 'カリウム', total: '', unit: 'mg', achv: '' },
@@ -32,35 +37,35 @@ const state = {
     iodine: { label: 'ヨウ素', total: '', unit: 'μg', achv: '' },
     selenium: { label: 'セレン', total: '', unit: 'μg', achv: '' },
     chromium: { label: 'クロム', total: '', unit: 'μg', achv: '' },
-    molybdenum: { label: 'モリブデン', total: '', unit: 'μg', achv: '' }
-  }
+    molybdenum: { label: 'モリブデン', total: '', unit: 'μg', achv: '' },
+  },
 };
 
 const getters = {
-  macro: state => state.macro,
-  vitamins: state => state.vitamins,
-  minerals: state => state.minerals
+  macro: (state) => state.macro,
+  vitamins: (state) => state.vitamins,
+  minerals: (state) => state.minerals,
 };
 
 const mutations = {
   setMacro(state, { total, achv }) {
-    Object.keys(state.macro).forEach(key => {
+    Object.keys(state.macro).forEach((key) => {
       state.macro[key].total = total[key];
       state.macro[key].achv = Math.trunc(achv[key] * 100);
     });
   },
   setVitamins(state, { total, achv }) {
-    Object.keys(state.vitamins).forEach(key => {
+    Object.keys(state.vitamins).forEach((key) => {
       state.vitamins[key].total = total[key];
       state.vitamins[key].achv = Math.trunc(achv[key] * 100);
     });
   },
   setMinerals(state, { total, achv }) {
-    Object.keys(state.minerals).forEach(key => {
+    Object.keys(state.minerals).forEach((key) => {
       state.minerals[key].total = total[key];
       state.minerals[key].achv = Math.trunc(achv[key] * 100);
     });
-  }
+  },
 };
 
 const actions = {
@@ -68,7 +73,7 @@ const actions = {
     context.commit('setMacro', { total: totals, achv: achvs });
     context.commit('setVitamins', { total: totals, achv: achvs });
     context.commit('setMinerals', { total: totals, achv: achvs });
-  }
+  },
 };
 
 export default {
@@ -76,5 +81,5 @@ export default {
   state,
   getters,
   mutations,
-  actions
+  actions,
 };

--- a/app/javascript/store/modules/pfcBalance.js
+++ b/app/javascript/store/modules/pfcBalance.js
@@ -1,13 +1,13 @@
 const state = {
   pct: {
-    pctP: '',
-    pctF: '',
-    pctC: '',
+    protein: '',
+    fat: '',
+    carbohydrate: '',
   },
   amt: {
-    amtP: '',
-    amtF: '',
-    amtC: '',
+    protein: '',
+    fat: '',
+    carbohydrate: '',
   },
 };
 
@@ -21,14 +21,14 @@ const getters = {
 
 const mutations = {
   updatePct(state, value) {
-    state.pct.pctP = value.pct_p;
-    state.pct.pctF = value.pct_f;
-    state.pct.pctC = value.pct_c;
+    state.pct.protein = value.protein;
+    state.pct.fat = value.fat;
+    state.pct.carbohydrate = value.carbohydrate;
   },
   updateAmt(state, value) {
-    state.amt.amtP = value.amt_p;
-    state.amt.amtF = value.amt_f;
-    state.amt.amtC = value.amt_c;
+    state.amt.protein = value.protein;
+    state.amt.fat = value.fat;
+    state.amt.carbohydrate = value.carbohydrate;
   },
 };
 

--- a/app/models/intake_achievement.rb
+++ b/app/models/intake_achievement.rb
@@ -70,9 +70,35 @@ class IntakeAchievement
     validates :zinc
   end
 
+  # Instance methods
+  def calc_intake_achievement(total, bmr, dri, pfc)
+    calc_cal_achv(total, bmr)
+    calc_nutritions_achv(total, dri, pfc)
+  end
+
   private
 
     def attr_validation
       valid?
+    end
+
+    def calc_cal_achv(total, bmr)
+      achv = (total["calorie"] / bmr).floor(2)
+      self.attributes = { calorie: achv }
+    end
+
+    def calc_nutritions_achv(total, dri, pfc)
+      params = attributes
+
+      total.each_key do |k|
+        next if k == "calorie"
+
+        params[k] = if dri[k].nil?
+                      (total[k] / pfc[k.to_sym]).floor(2)
+                    else
+                      (total[k] / dri[k]).floor(2)
+                    end
+      end
+      self.attributes = params
     end
 end

--- a/app/models/intake_achievement.rb
+++ b/app/models/intake_achievement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class IntakeAchievement
   include ActiveModel::Model
   include ActiveModel::Attributes

--- a/app/models/intake_achievement.rb
+++ b/app/models/intake_achievement.rb
@@ -1,0 +1,78 @@
+class IntakeAchievement
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # Attributes
+  attribute :calorie, :float, default: 0.0
+  attribute :protein, :float, default: 0.0
+  attribute :fat, :float, default: 0.0
+  attribute :carbohydrate, :float, default: 0.0
+  attribute :biotin, :float, default: 0.0
+  attribute :calcium, :float, default: 0.0
+  attribute :chromium, :float, default: 0.0
+  attribute :copper, :float, default: 0.0
+  attribute :folate, :float, default: 0.0
+  attribute :iodine, :float, default: 0.0
+  attribute :iron, :float, default: 0.0
+  attribute :magnesium, :float, default: 0.0
+  attribute :manganese, :float, default: 0.0
+  attribute :molybdenum, :float, default: 0.0
+  attribute :niacin, :float, default: 0.0
+  attribute :pantothenic_acid, :float, default: 0.0
+  attribute :phosphorus, :float, default: 0.0
+  attribute :potassium, :float, default: 0.0
+  attribute :selenium, :float, default: 0.0
+  attribute :vitamin_a, :float, default: 0.0
+  attribute :vitamin_b1, :float, default: 0.0
+  attribute :vitamin_b12, :float, default: 0.0
+  attribute :vitamin_b2, :float, default: 0.0
+  attribute :vitamin_b6, :float, default: 0.0
+  attribute :vitamin_c, :float, default: 0.0
+  attribute :vitamin_d, :float, default: 0.0
+  attribute :vitamin_e, :float, default: 0.0
+  attribute :vitamin_k, :float, default: 0.0
+  attribute :zinc, :float, default: 0.0
+
+  # Callbacks
+  define_model_callbacks :save
+  before_save :attr_validation
+
+  # Validates
+  with_options presence: true, numericality: true do
+    validates :biotin
+    validates :calcium
+    validates :calorie
+    validates :carbohydrate
+    validates :chromium
+    validates :copper
+    validates :fat
+    validates :folate
+    validates :iodine
+    validates :iron
+    validates :magnesium
+    validates :manganese
+    validates :molybdenum
+    validates :niacin
+    validates :pantothenic_acid
+    validates :phosphorus
+    validates :potassium
+    validates :protein
+    validates :selenium
+    validates :vitamin_a
+    validates :vitamin_b1
+    validates :vitamin_b12
+    validates :vitamin_b2
+    validates :vitamin_b6
+    validates :vitamin_c
+    validates :vitamin_d
+    validates :vitamin_e
+    validates :vitamin_k
+    validates :zinc
+  end
+
+  private
+
+    def attr_validation
+      valid?
+    end
+end

--- a/app/models/nutrition_total.rb
+++ b/app/models/nutrition_total.rb
@@ -1,0 +1,78 @@
+class NutritionTotal
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # Attributes
+  attribute :calorie, :float, default: 0.0
+  attribute :protein, :float, default: 0.0
+  attribute :fat, :float, default: 0.0
+  attribute :carbohydrate, :float, default: 0.0
+  attribute :biotin, :float, default: 0.0
+  attribute :calcium, :float, default: 0.0
+  attribute :chromium, :float, default: 0.0
+  attribute :copper, :float, default: 0.0
+  attribute :folate, :float, default: 0.0
+  attribute :iodine, :float, default: 0.0
+  attribute :iron, :float, default: 0.0
+  attribute :magnesium, :float, default: 0.0
+  attribute :manganese, :float, default: 0.0
+  attribute :molybdenum, :float, default: 0.0
+  attribute :niacin, :float, default: 0.0
+  attribute :pantothenic_acid, :float, default: 0.0
+  attribute :phosphorus, :float, default: 0.0
+  attribute :potassium, :float, default: 0.0
+  attribute :selenium, :float, default: 0.0
+  attribute :vitamin_a, :float, default: 0.0
+  attribute :vitamin_b1, :float, default: 0.0
+  attribute :vitamin_b12, :float, default: 0.0
+  attribute :vitamin_b2, :float, default: 0.0
+  attribute :vitamin_b6, :float, default: 0.0
+  attribute :vitamin_c, :float, default: 0.0
+  attribute :vitamin_d, :float, default: 0.0
+  attribute :vitamin_e, :float, default: 0.0
+  attribute :vitamin_k, :float, default: 0.0
+  attribute :zinc, :float, default: 0.0
+
+  # Callbacks
+  define_model_callbacks :save
+  before_save :attr_validation
+
+  # Validates
+  with_options presence: true, numericality: true do
+    validates :biotin
+    validates :calcium
+    validates :calorie
+    validates :carbohydrate
+    validates :chromium
+    validates :copper
+    validates :fat
+    validates :folate
+    validates :iodine
+    validates :iron
+    validates :magnesium
+    validates :manganese
+    validates :molybdenum
+    validates :niacin
+    validates :pantothenic_acid
+    validates :phosphorus
+    validates :potassium
+    validates :protein
+    validates :selenium
+    validates :vitamin_a
+    validates :vitamin_b1
+    validates :vitamin_b12
+    validates :vitamin_b2
+    validates :vitamin_b6
+    validates :vitamin_c
+    validates :vitamin_d
+    validates :vitamin_e
+    validates :vitamin_k
+    validates :zinc
+  end
+
+  private
+
+    def attr_validation
+      valid?
+    end
+end

--- a/app/models/nutrition_total.rb
+++ b/app/models/nutrition_total.rb
@@ -70,7 +70,21 @@ class NutritionTotal
     validates :zinc
   end
 
-  private
+  # Instance methods
+  def calc_intake_total(foods)
+    params = attributes
+
+    params.each_key do |k|
+      sum = 0
+      foods.each do |f|
+        sum += f[k] * f.reference_amount
+      end
+      params[k] = sum.floor(4)
+    end
+    self.attributes = params
+  end
+
+  # private
 
     def attr_validation
       valid?

--- a/app/models/nutrition_total.rb
+++ b/app/models/nutrition_total.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NutritionTotal
   include ActiveModel::Model
   include ActiveModel::Attributes

--- a/app/models/nutrition_total.rb
+++ b/app/models/nutrition_total.rb
@@ -84,7 +84,7 @@ class NutritionTotal
     self.attributes = params
   end
 
-  # private
+  private
 
     def attr_validation
       valid?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,12 +70,12 @@ class User < ApplicationRecord
   end
 
   def set_attributes_for_pfc
-    { pct: { pct_p: percentage_protein,
-             pct_f: percentage_fat,
-             pct_c: percentage_carbohydrate },
-      amt: { amt_p: calc_amount_protein.floor,
-             amt_f: calc_amount_fat.floor,
-             amt_c: calc_amount_carbo.floor } }
+    { pct: { protein: percentage_protein,
+             fat: percentage_fat,
+             carbohydrate: percentage_carbohydrate },
+      amt: { protein: calc_amount_protein.floor,
+             fat: calc_amount_fat.floor,
+             carbohydrate: calc_amount_carbo.floor } }
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       resource :mypage, only: %i[show]
       resource :bmr, only: %i[update]
       resource :users_dietary_reference_intake, only: %i[update]
+      resource :suggestion, only: %i[show]
     end
   end
 
@@ -75,6 +76,7 @@ end
 #                                       PUT    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
 # api_v1_users_dietary_reference_intake PATCH  /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}
 #                                       PUT    /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}
+#                     api_v1_suggestion GET    /api/v1/suggestion(.:format)                                                             api/v1/suggestions#show {:format=>/json/}
 #                         line_callback POST   /line/callback(.:format)                                                                 line/linebot#callback {:format=>/json/}
 #                             line_link GET    /line/link(.:format)                                                                     line/authentications#link
 #                                       POST   /line/link(.:format)                                                                     line/authentications#create


### PR DESCRIPTION
## 概要
rakeタスクにより作成した食事内容の提案、およびそれにより摂取できる栄養の合計値と、
目標に対する達成度を参照するための画面を作成した。
おおまかなレイアウトは整えたが、細かい調整はまだまだ必要である。

また、PFCのパーセンテージ及びg数を取得するUserモデルのインスタンスメソッドを
修正する必要ができ、それに伴ってMyPageのフロントの処理、およびストアの修正を
行った。

<br />


## チェックリスト
- [x] コントローラーの作成
- [x] バックエンドのルート定義
- [x] フロントのルート定義
- [x] ストアの作成
- [x] ページの作成
- [x] リントチェック
- [x] 動作確認


<br />

closes #47 
