### PR TITLE
LINE Messaging APIによりユーザー自身の情報を返す機能を作成

### DIFF
--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -80,11 +80,13 @@ module Line
 
       # Event::Messageのテキストの内容により処理を振り分ける
       def reply_text_message(event)
+        line_id = (event["source"]["userId"])
+
         case event.message["text"]
         when "delete linking"
-          disconnecting_accounts(event["source"]["userId"])
-        when "bmr"
-          set_users_bmr(event["source"]["userId"])
+          disconnecting_accounts(line_id)
+        when "BMR & PFC"
+          set_users_bmr_pfc(line_id)
         else
           # 所定の文言以外にはエラーメッセージを返す
           set_reply_text("ちょっと何言ってるかわからない")
@@ -96,12 +98,19 @@ module Line
         { type: 'text', text: text }
       end
 
-      def set_users_bmr(line_id)
+      def set_users_bmr_pfc(line_id)
         target_user = User.where(line_user_id: line_id)[0]
 
         if target_user.present?
           bmr = target_user.bmr
-          set_reply_text("BMR: #{bmr}kcal")
+          pfc = target_user.set_attributes_for_pfc[:amt]
+
+          text = "#{target_user.name}さん \n" +
+                 "BMR: #{bmr}kcal \n" +
+                 "P: #{pfc[:protein]}g \n" +
+                 "F: #{pfc[:fat]}g \n" +
+                 "C: #{pfc[:carbohydrate]}g \n"
+          set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")
         end

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -81,14 +81,16 @@ module Line
       # Event::Messageのテキストの内容により処理を振り分ける
       def reply_text_message(event)
         line_id = event["source"]["userId"]
+        Rails.logger.debug "代入せず: #{event["source"]["userId"]}"
+        Rails.logger.debug "代入: #{line_id}"
 
         case event.message["text"]
         when "アカウント連携解除"
-          disconnecting_accounts(line_id)
+          disconnecting_accounts(event["source"]["userId"])
         when "BMR & PFC"
-          set_users_bmr_pfc(line_id)
+          set_users_bmr_pfc(event["source"]["userId"])
         when "today's menu"
-          set_users_suggested_foods(line_id)
+          set_users_suggested_foods(event["source"]["userId"])
         else
           # 所定の文言以外にはエラーメッセージを返す
           set_reply_text("ちょっと何言ってるかわからない")
@@ -102,7 +104,9 @@ module Line
 
       # ユーザーのBMR/PFC情報を返答
       def set_users_bmr_pfc(line_id)
+        Rails.logger.debug "メソッド突入: #{line_id}"
         target_user = User.where(line_user_id: line_id)[0]
+        Rails.logger.debug "ユーザー: #{target_user.name}"
 
         if target_user.present?
           bmr = target_user.bmr

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -109,10 +109,10 @@ module Line
           pfc = target_user.set_attributes_for_pfc[:amt]
 
           text = "#{target_user.name}さん \n" +
-                 "  BMR: #{bmr}kcal \n" +
-                 "    P: #{pfc[:protein]}g \n" +
-                 "    F: #{pfc[:fat]}g \n" +
-                 "    C: #{pfc[:carbohydrate]}g"
+                 "BMR: #{bmr}kcal \n" +
+                 "  P: #{pfc[:protein]}g \n" +
+                 "  F: #{pfc[:fat]}g \n" +
+                 "  C: #{pfc[:carbohydrate]}g"
           set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -87,6 +87,8 @@ module Line
           disconnecting_accounts(line_id)
         when "BMR & PFC"
           set_users_bmr_pfc(line_id)
+        when "today's menu"
+          set_users_suggested_foods(line_id)
         else
           # 所定の文言以外にはエラーメッセージを返す
           set_reply_text("ちょっと何言ってるかわからない")
@@ -98,6 +100,7 @@ module Line
         { type: 'text', text: text }
       end
 
+      # ユーザーのBMR/PFC情報を返答
       def set_users_bmr_pfc(line_id)
         target_user = User.where(line_user_id: line_id)[0]
 
@@ -110,6 +113,22 @@ module Line
                  "P: #{pfc[:protein]}g \n" +
                  "F: #{pfc[:fat]}g \n" +
                  "C: #{pfc[:carbohydrate]}g \n"
+          set_reply_text(text)
+        else
+          set_reply_text("ユーザーの取得に失敗しました")
+        end
+      end
+
+      def set_users_suggested_foods(line_id)
+        target_user = User.where(line_user_id: line_id)[0]
+
+        if target_user.present?
+          foods = target_user.suggested_foods
+          text = "#{Time.zone.today}"
+
+          foods.each do |f|
+            text = text + "\n #{f.name} #{f.subname}: #{f.reference_amount * 100}g"
+          end
           set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -83,7 +83,7 @@ module Line
         line_id = (event["source"]["userId"])
 
         case event.message["text"]
-        when "delete linking"
+        when "アカウント連携解除"
           disconnecting_accounts(line_id)
         when "BMR & PFC"
           set_users_bmr_pfc(line_id)

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -80,7 +80,7 @@ module Line
 
       # Event::Messageのテキストの内容により処理を振り分ける
       def reply_text_message(event)
-        line_id = (event["source"]["userId"])
+        line_id = event["source"]["userId"]
 
         case event.message["text"]
         when "アカウント連携解除"

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -110,9 +110,9 @@ module Line
 
           text = "#{target_user.name}さん \n" +
                  "BMR: #{bmr}kcal \n" +
-                 "  P: #{pfc[:protein]}g \n" +
-                 "  F: #{pfc[:fat]}g \n" +
-                 "  C: #{pfc[:carbohydrate]}g"
+                 "P: #{pfc[:protein]}g \n" +
+                 "F: #{pfc[:fat]}g \n" +
+                 "C: #{pfc[:carbohydrate]}g"
           set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -81,16 +81,14 @@ module Line
       # Event::Messageのテキストの内容により処理を振り分ける
       def reply_text_message(event)
         line_id = event["source"]["userId"]
-        Rails.logger.debug "代入せず: #{event["source"]["userId"]}"
-        Rails.logger.debug "代入: #{line_id}"
 
         case event.message["text"]
         when "アカウント連携解除"
-          disconnecting_accounts(event["source"]["userId"])
+          disconnecting_accounts(line_id)
         when "BMR & PFC"
-          set_users_bmr_pfc(event["source"]["userId"])
+          set_users_bmr_pfc(line_id)
         when "today's menu"
-          set_users_suggested_foods(event["source"]["userId"])
+          set_users_suggested_foods(line_id)
         else
           # 所定の文言以外にはエラーメッセージを返す
           set_reply_text("ちょっと何言ってるかわからない")
@@ -104,19 +102,17 @@ module Line
 
       # ユーザーのBMR/PFC情報を返答
       def set_users_bmr_pfc(line_id)
-        Rails.logger.debug "メソッド突入: #{line_id}"
         target_user = User.where(line_user_id: line_id)[0]
-        Rails.logger.debug "ユーザー: #{target_user.name}"
 
         if target_user.present?
           bmr = target_user.bmr
           pfc = target_user.set_attributes_for_pfc[:amt]
 
           text = "#{target_user.name}さん \n" +
-                 "BMR: #{bmr}kcal \n" +
-                 "P: #{pfc[:protein]}g \n" +
-                 "F: #{pfc[:fat]}g \n" +
-                 "C: #{pfc[:carbohydrate]}g \n"
+                 "  BMR: #{bmr}kcal \n" +
+                 "    P: #{pfc[:protein]}g \n" +
+                 "    F: #{pfc[:fat]}g \n" +
+                 "    C: #{pfc[:carbohydrate]}g"
           set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")
@@ -131,7 +127,7 @@ module Line
           text = "#{Time.zone.today}"
 
           foods.each do |f|
-            text = text + "\n #{f.name} #{f.subname}: #{f.reference_amount * 100}g"
+            text = text + "\n  #{f.name} #{f.subname}: #{ (f.reference_amount * 100).floor }g"
           end
           set_reply_text(text)
         else

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # TODO: LINE機能のデバック時にのみレベルをdebugに
   # TODO: 終了後warnに戻すこと
-  config.log_level = :warn
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## 概要
LINEのリッチメニュー からの入力に応じて、送信元のユーザーごとに、自身の情報を返答する機能を作成した。
今回作成したのは以下の2点に加え、1点の修正である。

- BMR / PFCの情報を返す機能
- 当日の食事内容を返す機能
- アカウント連携解除用のtextの内容を変更
<br />


## チェックリスト
- [x] BMR と PFCの情報を返す機能
- [x] 当日の食事内容を返す機能
- [x] 連携解除処理の修正
- [x] リントチェック
- [x] 動作確認

<br />

closes #48 
