### PR TITLE
LINE Messaging APIにより指定した時間に食事内容を通知する機能を作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Metrics/BlockLength:
     - 'spec/**/*'
   Max: 85
 
+Metrics/ClassLength:
+  Max: 120
+
 Layout/LineLength:
   Exclude:
     - 'config/**/*'

--- a/app/controllers/api/v1/user_accounts_controller.rb
+++ b/app/controllers/api/v1/user_accounts_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UserAccountsController < Api::V1::BaseController
+      def show
+      end
+
+      def update
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/user_accounts_controller.rb
+++ b/app/controllers/api/v1/user_accounts_controller.rb
@@ -4,10 +4,23 @@ module Api
   module V1
     class UserAccountsController < Api::V1::BaseController
       def show
+        attributes = current_user.set_account_params
+        render json: attributes
       end
 
       def update
+        if current_user.update(user_params)
+          head :ok
+        else
+          render400(nil, @user.errors.full_messages)
+        end
       end
+
+      private
+
+        def user_params
+          params.require(:user).permit(:line_notification_enabled, :mealtime_first)
+        end
     end
   end
 end

--- a/app/controllers/line/linebot_controller.rb
+++ b/app/controllers/line/linebot_controller.rb
@@ -123,12 +123,7 @@ module Line
         target_user = User.where(line_user_id: line_id)[0]
 
         if target_user.present?
-          foods = target_user.suggested_foods
-          text = "#{Time.zone.today}"
-
-          foods.each do |f|
-            text = text + "\n  #{f.name} #{f.subname}: #{ (f.reference_amount * 100).floor }g"
-          end
+          text = target_user.set_line_notification_text
           set_reply_text(text)
         else
           set_reply_text("ユーザーの取得に失敗しました")

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -34,7 +34,7 @@ export default {
   components: {
     BmrForm,
     MyPageDriIndex,
-    MyPageAccountForm
+    MyPageAccountForm,
   },
   mounted() {
     this.setData();

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -16,7 +16,7 @@
         </v-row>
       </v-tab-item>
       <v-tab-item class="tab-item">
-        <p>comming soon...</p>
+        <my-page-account-form />
       </v-tab-item>
       <v-tab-item class="tab-item">
         <p>comming soon...</p>
@@ -28,11 +28,13 @@
 <script>
 import BmrForm from '../parts/BmrForm';
 import MyPageDriIndex from '../parts/MyPageDriIndex';
+import MyPageAccountForm from '../parts/MyPageAccountForm';
 
 export default {
   components: {
     BmrForm,
     MyPageDriIndex,
+    MyPageAccountForm
   },
   mounted() {
     this.setData();

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -70,6 +70,9 @@
                 </v-btn>
               </v-time-picker>
             </v-dialog>
+            <div class="base--text text-caption">
+              ※サーバーの負荷などの要因により通知のタイミングが数分ほど遅れる場合があります
+            </div>
           </div>
         </v-card-text>
         <v-card-actions>

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -32,6 +32,7 @@
                   prepend-icon="mdi-clock-time-four-outline"
                   color="base"
                   dark
+                  readonly
                   v-bind="attrs"
                   v-on="on"
                 ></v-text-field>

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -1,0 +1,145 @@
+<template>
+  <v-card id="account-form" color="primary" flat tile>
+    <validation-observer ref="observer" v-slot="{ handleSubmit }">
+      <v-form @submit.prevent="handleSubmit(updateAccount)">
+        <v-card-text>
+          <template v-if="railsErrors.show">
+            <v-alert class="text-center" dense type="error">
+              <template v-for="e in railsErrors.errorMessages">
+                <p :key="e">{{ e }}</p>
+              </template>
+            </v-alert>
+          </template>
+
+          <v-switch
+            v-model="user.line_notification_enabled"
+            color="base"
+            dark
+            dense
+            flat
+            label="LINE通知機能"
+          ></v-switch>
+          <div v-show="user.line_notification_enabled">
+            <v-dialog
+              ref="dialog"
+              v-model="timePicker"
+              :return-value.sync="user.mealtime_first"
+            >
+              <template #activator="{ on, attrs }">
+                <v-text-field
+                  v-model="user.mealtime_first"
+                  label="食事内容を通知する時間"
+                  prepend-icon="mdi-clock-time-four-outline"
+                  color="base"
+                  dark
+                  v-bind="attrs"
+                  v-on="on"
+                ></v-text-field>
+              </template>
+              <v-time-picker
+                v-if="timePicker"
+                v-model="user.mealtime_first"
+                :allowed-hours="allowedHours"
+                :allowed-minutes="allowedMinutes"
+                color="primary"
+                flat
+                format="24hr"
+                min="7:00"
+                max="23:00"
+                scrollable
+                width="270"
+              >
+              <v-btn
+                outlined
+                small
+                tile
+                clor="primary"
+                @click="timePicker = false"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                outlined
+                small
+                tile
+                color="primary"
+                @click="$refs.dialog.save(user.mealtime_first)"
+              >
+                OK
+              </v-btn>
+              </v-time-picker>
+            </v-dialog>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn type="submit" color="base" outlined>更新</v-btn>
+        </v-card-actions>
+      </v-form>
+    </validation-observer>
+  </v-card>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      user: {
+        line_notification_enabled: false,
+        mealtime_first: '',
+      },
+      timePicker: false,
+      railsErrors: {
+        show: false,
+        message: '',
+        errorMessages: [],
+      },
+    }
+  },
+  mounted() {
+    this.setAccount();
+  },
+  methods: {
+    setAccount() {
+      this.axios
+        .get('/api/v1/user_account')
+        .then((res) => {
+          console.log(res.status);
+          console.log(res.data);
+
+          this.user = res.data;
+        })
+        .catch((e) => {
+          console.log(e.response.status);
+        });
+    },
+    updateAccount() {
+      this.axios
+        .patch('/api/v1/user_account', { user: this.user })
+        .then((res) => {
+          console.log(res.status);
+
+          this.$store.commit('flashMessage/setMessage', {
+            type: 'success',
+            message: '更新に成功しました',
+          })
+        })
+        .catch((error) => {
+          let e = error.response;
+          console.error(e.status);
+
+          if (e.data.errors) {
+            this.railsErrors.errorMessages = e.data.errors;
+          }
+          if (this.railsErrors.errorMessages.length != 0) {
+            this.railsErrors.show = true;
+            setTimeout(() => {
+              this.railsErrors.show = false;
+            }, 5000);
+          }
+        });
+    },
+    allowedHours: v => v >= 7 && v <= 23,
+    allowedMinutes: m => m % 10 === 0,
+  }
+};
+</script>

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -48,26 +48,26 @@
                 min="7:00"
                 max="23:00"
                 scrollable
-                width="270"
+                full-width
               >
-              <v-btn
-                outlined
-                small
-                tile
-                clor="primary"
-                @click="timePicker = false"
-              >
-                Cancel
-              </v-btn>
-              <v-btn
-                outlined
-                small
-                tile
-                color="primary"
-                @click="$refs.dialog.save(user.mealtime_first)"
-              >
-                OK
-              </v-btn>
+                <v-btn
+                  outlined
+                  small
+                  tile
+                  clor="primary"
+                  @click="timePicker = false"
+                >
+                  Cancel
+                </v-btn>
+                <v-btn
+                  outlined
+                  small
+                  tile
+                  color="primary"
+                  @click="$refs.dialog.save(user.mealtime_first)"
+                >
+                  OK
+                </v-btn>
               </v-time-picker>
             </v-dialog>
           </div>
@@ -94,7 +94,7 @@ export default {
         message: '',
         errorMessages: [],
       },
-    }
+    };
   },
   mounted() {
     this.setAccount();
@@ -122,7 +122,7 @@ export default {
           this.$store.commit('flashMessage/setMessage', {
             type: 'success',
             message: '更新に成功しました',
-          })
+          });
         })
         .catch((error) => {
           let e = error.response;
@@ -139,8 +139,8 @@ export default {
           }
         });
     },
-    allowedHours: v => v >= 7 && v <= 23,
-    allowedMinutes: m => m % 10 === 0,
-  }
+    allowedHours: (v) => v >= 7 && v <= 23,
+    allowedMinutes: (m) => m % 30 === 0,
+  },
 };
 </script>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: :new_or_changes_password
   validates :password_confirmation, presence: true, if: :new_or_changes_password
   validates :line_notification_enabled, inclusion: { in: [true, false] }
-  validates :mealtime_first, mealtime: true, format: { with: /\A([01][0-9]|2[0-3]):[0-5]0\z/, message: "の値の形式が不正です" }, allow_nil: true
+  validates :mealtime_first, mealtime: true, allow_nil: true
 
   # Instance methods
   def calc_age
@@ -74,7 +74,7 @@ class User < ApplicationRecord
   def set_account_params
     {
       line_notification_enabled: line_notification_enabled,
-      mealtime_first: mealtime_first.strftime('%R')
+      mealtime_first: mealtime_first&.strftime('%R')
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,6 @@ class User < ApplicationRecord
   scope :set_mealtime, -> { where.not(mealtime_first: nil) }
   scope :wish_line_notice, -> { linked_line.notice_enable.set_mealtime }
 
-
   # Encryption
   encrypts :line_user_id
   blind_index :line_user_id
@@ -101,12 +100,12 @@ class User < ApplicationRecord
 
     foods = suggested_foods
     foods.each do |f|
-      +text << "\n#{f.name} #{f.subname}: #{ (f.reference_amount * 100).floor }g"
+      +text << "\n#{f.name} #{f.subname}: #{(f.reference_amount * 100).floor}g"
       total_cal += (f.calorie * f.reference_amount).floor
     end
-    text << "\n#{total_cal} / #{(bmr).floor}kcal"
+    text << "\n#{total_cal} / #{bmr.floor}kcal"
 
-    return text
+    text
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,21 @@ class User < ApplicationRecord
              carbohydrate: calc_amount_carbo.floor } }
   end
 
+  # LINE自動通知機能用
+  def set_line_notification_text
+    text = +"#{Time.zone.today}\n"
+    total_cal = 0
+
+    foods = suggested_foods
+    foods.each do |f|
+      +text << "\n#{f.name} #{f.subname}: #{ (f.reference_amount * 100).floor }g"
+      total_cal += (f.calorie * f.reference_amount).floor
+    end
+    text << "\n#{total_cal} / #{(bmr).floor}kcal"
+
+    return text
+  end
+
   private
 
     def set_attributes_for_bmr

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,6 @@ class User < ApplicationRecord
     validates :role
     validates :gender
     validates :height, numericality: { only_integer: true }
-    validates :line_notification_enabled
 
     with_options numericality: true do
       validates :weight
@@ -45,8 +44,8 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 5 }, if: :new_or_changes_password
   validates :password, confirmation: true, if: :new_or_changes_password
   validates :password_confirmation, presence: true, if: :new_or_changes_password
-  validates :mealtime_first, mealtime: true, allow_nil: true
-  # format: { with: /\A([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\z/ }
+  validates :line_notification_enabled, inclusion: { in: [true, false] }
+  validates :mealtime_first, mealtime: true, format: { with: /\A([01][0-9]|2[0-3]):[0-5]0\z/, message: "の値の形式が不正です" }, allow_nil: true
 
   # Instance methods
   def calc_age

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,7 +95,7 @@ class User < ApplicationRecord
 
   # LINE自動通知機能用
   def set_line_notification_text
-    text = +"#{Time.zone.today}"
+    text = Time.zone.today.to_s
     total_cal = 0
 
     foods = suggested_foods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,15 +95,15 @@ class User < ApplicationRecord
 
   # LINE自動通知機能用
   def set_line_notification_text
-    text = +"#{Time.zone.today}\n"
+    text = +"#{Time.zone.today}"
     total_cal = 0
 
     foods = suggested_foods
     foods.each do |f|
-      +text << "\n#{f.name} #{f.subname}: #{(f.reference_amount * 100).floor}g"
+      text << "\n- #{f.name} #{f.subname}: #{(f.reference_amount * 100).floor}g"
       total_cal += (f.calorie * f.reference_amount).floor
     end
-    text << "\n#{total_cal} / #{bmr.floor}kcal"
+    text << "\n\n#{total_cal} / #{bmr.floor}kcal"
 
     text
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,13 @@ class User < ApplicationRecord
     }
   end
 
+  def set_account_params
+    {
+      line_notification_enabled: line_notification_enabled,
+      mealtime_first: mealtime_first.strftime('%R')
+    }
+  end
+
   def set_attributes_for_pfc
     { pct: { protein: percentage_protein,
              fat: percentage_fat,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,13 @@ class User < ApplicationRecord
   has_many :suggestions, dependent: :destroy
   has_many :suggested_foods, through: :suggestions, source: :food
 
+  # Scopes
+  scope :linked_line, -> { where.not(line_user_id: nil) }
+  scope :notice_enable, -> { where(line_notification_enabled: true) }
+  scope :set_mealtime, -> { where.not(mealtime_first: nil) }
+  scope :wish_line_notice, -> { linked_line.notice_enable.set_mealtime }
+
+
   # Encryption
   encrypts :line_user_id
   blind_index :line_user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,8 +119,10 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
+#  line_notification_enabled   :boolean          default(FALSE), not null
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
+#  mealtime_first              :time
 #  name                        :string           default("noname"), not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
     validates :role
     validates :gender
     validates :height, numericality: { only_integer: true }
+    validates :line_notification_enabled
 
     with_options numericality: true do
       validates :weight
@@ -44,6 +45,8 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 5 }, if: :new_or_changes_password
   validates :password, confirmation: true, if: :new_or_changes_password
   validates :password_confirmation, presence: true, if: :new_or_changes_password
+  validates :mealtime_first, mealtime: true, allow_nil: true
+  # format: { with: /\A([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\z/ }
 
   # Instance methods
   def calc_age

--- a/app/validators/mealtime_validator.rb
+++ b/app/validators/mealtime_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BirthValidator < ActiveModel::EachValidator
+class MealtimeValidator < ActiveModel::EachValidator
   def validate_each(record, _attribute, value)
     return unless value
     time = value.strftime('%R')

--- a/app/validators/mealtime_validator.rb
+++ b/app/validators/mealtime_validator.rb
@@ -3,10 +3,9 @@
 class MealtimeValidator < ActiveModel::EachValidator
   def validate_each(record, _attribute, value)
     return unless value
+
     time = value.strftime('%R')
 
-    if time < "07:00" || time > "23:00"
-      record.errors.add(:mealtime_first, "通知の時間は7:00 - 23:00の間で設定してください")
-    end
+    record.errors.add(:mealtime_first, "通知の時間は7:00 - 23:00の間で設定してください") if time < "07:00" || time > "23:00"
   end
 end

--- a/app/validators/mealtime_validator.rb
+++ b/app/validators/mealtime_validator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BirthValidator < ActiveModel::EachValidator
+  def validate_each(record, _attribute, value)
+    return unless value
+    time = value.strftime('%R')
+
+    if time < "07:00" || time > "23:00"
+      record.errors.add(:mealtime_first, "通知の時間は7:00 - 23:00の間で設定してください")
+    end
+  end
+end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -25,7 +25,7 @@
       </tr>
       <tr class="admin-t-row">
         <th class="admin-t-head"><%= User.human_attribute_name(:mealtime_first) %></th>
-        <td class="admin-t-data"><%= @user.mealtime_first.strftime('%R') %></td>
+        <td class="admin-t-data"><%= @user.mealtime_first&.strftime('%R') %></td>
       </tr>
       <tr class="admin-t-row">
         <th class="admin-t-head"><%= User.human_attribute_name(:gender) %></th>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -20,6 +20,14 @@
         <td class="admin-t-data"><%= @user.email %></td>
       </tr>
       <tr class="admin-t-row">
+        <th class="admin-t-head"><%= User.human_attribute_name(:line_notification_enabled) %></th>
+        <td class="admin-t-data"><%= @user.line_notification_enabled %></td>
+      </tr>
+      <tr class="admin-t-row">
+        <th class="admin-t-head"><%= User.human_attribute_name(:mealtime_first) %></th>
+        <td class="admin-t-data"><%= @user.mealtime_first.strftime('%R') %></td>
+      </tr>
+      <tr class="admin-t-row">
         <th class="admin-t-head"><%= User.human_attribute_name(:gender) %></th>
         <td class="admin-t-data"><%= @user.gender_i18n %></td>
       </tr>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # TODO: LINE機能のデバック時にのみレベルをdebugに
   # TODO: 終了後warnに戻すこと
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # TODO: LINE機能のデバック時にのみレベルをdebugに
   # TODO: 終了後warnに戻すこと
-  config.log_level = :warn
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -24,6 +24,8 @@ ja:
         percentage_fat: "脂質の割合"
         percentage_carbohydrate: "炭水化物の割合"
         dietary_reference_intake_id: "食事摂取基準ID"
+        line_notification_enabled: "LINE通知機能"
+        mealtime_first: "通知する時間"
         role: "権限"
         created_at: "登録日時"
         updated_at: "更新日時"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       resource :registration, only: %i[create]
       resource :authentication, only: %i[create destroy]
       resource :mypage, only: %i[show]
+      resource :user_account, only: %i[show update]
       resource :bmr, only: %i[update]
       resource :users_dietary_reference_intake, only: %i[update]
       resource :suggestion, only: %i[show]
@@ -75,6 +76,9 @@ end
 #                 api_v1_authentication DELETE /api/v1/authentication(.:format)                                                         api/v1/authentications#destroy {:format=>/json/}
 #                                       POST   /api/v1/authentication(.:format)                                                         api/v1/authentications#create {:format=>/json/}
 #                         api_v1_mypage GET    /api/v1/mypage(.:format)                                                                 api/v1/mypages#show {:format=>/json/}
+#                   api_v1_user_account GET    /api/v1/user_account(.:format)                                                           api/v1/user_accounts#show {:format=>/json/}
+#                                       PATCH  /api/v1/user_account(.:format)                                                           api/v1/user_accounts#update {:format=>/json/}
+#                                       PUT    /api/v1/user_account(.:format)                                                           api/v1/user_accounts#update {:format=>/json/}
 #                            api_v1_bmr PATCH  /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
 #                                       PUT    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
 # api_v1_users_dietary_reference_intake PATCH  /api/v1/users_dietary_reference_intake(.:format)                                         api/v1/users_dietary_reference_intakes#update {:format=>/json/}

--- a/db/migrate/20211023062812_add_column_mealtime_and_notificationenabled_to_users.rb
+++ b/db/migrate/20211023062812_add_column_mealtime_and_notificationenabled_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnMealtimeAndNotificationenabledToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :mealtime_first, :time
+    add_column :users, :line_notification_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_16_124921) do
+ActiveRecord::Schema.define(version: 2021_10_23_062812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,8 @@ ActiveRecord::Schema.define(version: 2021_10_16_124921) do
     t.string "line_nonce"
     t.text "line_user_id_ciphertext"
     t.string "line_user_id_bidx"
+    t.time "mealtime_first"
+    t.boolean "line_notification_enabled", default: false, null: false
     t.index ["dietary_reference_intake_id"], name: "index_users_on_dietary_reference_intake_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["line_user_id_bidx"], name: "index_users_on_line_user_id_bidx", unique: true

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -49,19 +49,24 @@ namespace :scheduler do
 
     t = Time.zone.now
     time_now = t - (t.to_i % (60 * 30))
+    Rails.logger.debug "Time now: #{time_now}"
 
     User.wish_line_notice.find_each do |user|
+      Rails.logger.debug "User: #{user.name}"
+
       if user.mealtime_first.strftime('%R') == time_now.strftime('%R')
         to_id = user.line_user_id
 
         text = user.set_line_notification_text
         message = { type: "text", text: text }
+        Rails.logger.debug "Message: #{message}"
 
         client = Line::Bot::Client.new do |config|
           config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]
           config.channel_token = Rails.application.credentials.line[:CHANNEL_TOKEN]
         end
-        client.push_message(to_id, message)
+        response = client.push_message(to_id, message)
+        p response
       end
     end
   end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,33 +1,6 @@
 # frozen_string_literal: true
 
 namespace :scheduler do
-  desc "動作確認用"
-  task test_scheduler: :environment do
-    puts "Scheduler test is works."
-  end
-
-  desc "LINEプッシュメッセージ送信テスト"
-  task push_line_message_test: :environment do
-    require 'line/bot'
-
-    User.where.not(line_user_id: nil).find_each do |user|
-      to_name = user.name
-      to_id = user.line_user_id
-      bmr = user.bmr
-
-      message = {
-        type: "text",
-        text: "#{to_name}さんのBMR: #{bmr}kcal"
-      }
-      client = Line::Bot::Client.new do |config|
-        config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]
-        config.channel_token = Rails.application.credentials.line[:CHANNEL_TOKEN]
-      end
-      response = client.push_message(to_id, message)
-      p response
-    end
-  end
-
   desc "期限切れのsuggestionを削除"
   task destroy_expied_suggestions: :environment do
     User.find_each do |user|
@@ -67,6 +40,57 @@ namespace :scheduler do
       rescue StandardError => e
         Rails.logger.warn "User#{user.id}: Failed to save the suggestion. Cause...'#{e}'"
       end
+    end
+  end
+
+  desc "ユーザーの設定した時間に食事内容を通知"
+  task notice_suggestion: :environment do
+    require 'line/bot'
+
+    t = Time.zone.now
+    time_now = t - (t.to_i % (60 * 30))
+
+    User.wish_line_notice.find_each do |user|
+      if user.mealtime_first.strftime('%R') == time_now.strftime('%R')
+        to_id = user.line_user_id
+
+        text = user.set_line_notification_text
+        message = { type: "text", text: text }
+
+        client = Line::Bot::Client.new do |config|
+          config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]
+          config.channel_token = Rails.application.credentials.line[:CHANNEL_TOKEN]
+        end
+        response = client.push_message(to_id, message)
+      end
+    end
+  end
+
+  # 以下動作テスト用のタスク
+  desc "動作確認用"
+  task test_scheduler: :environment do
+    puts "Scheduler test is works."
+  end
+
+  desc "LINEプッシュメッセージ送信テスト"
+  task push_line_message_test: :environment do
+    require 'line/bot'
+
+    User.where.not(line_user_id: nil).find_each do |user|
+      to_name = user.name
+      to_id = user.line_user_id
+      bmr = user.bmr
+
+      message = {
+        type: "text",
+        text: "#{to_name}さんのBMR: #{bmr}kcal"
+      }
+      client = Line::Bot::Client.new do |config|
+        config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]
+        config.channel_token = Rails.application.credentials.line[:CHANNEL_TOKEN]
+      end
+      response = client.push_message(to_id, message)
+      p response
     end
   end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -61,7 +61,7 @@ namespace :scheduler do
           config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]
           config.channel_token = Rails.application.credentials.line[:CHANNEL_TOKEN]
         end
-        response = client.push_message(to_id, message)
+        client.push_message(to_id, message)
       end
     end
   end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -49,17 +49,13 @@ namespace :scheduler do
 
     t = Time.zone.now
     time_now = t - (t.to_i % (60 * 30))
-    Rails.logger.debug "Time now: #{time_now}"
 
     User.wish_line_notice.find_each do |user|
-      Rails.logger.debug "User: #{user.name}"
-
       if user.mealtime_first.strftime('%R') == time_now.strftime('%R')
         to_id = user.line_user_id
 
         text = user.set_line_notification_text
         message = { type: "text", text: text }
-        Rails.logger.debug "Message: #{message}"
 
         client = Line::Bot::Client.new do |config|
           config.channel_secret = Rails.application.credentials.line[:CHANNEL_SECRET]

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,8 +17,10 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
+#  line_notification_enabled   :boolean          default(FALSE), not null
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
+#  mealtime_first              :time
 #  name                        :string           default("noname"), not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,8 +18,10 @@ end
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
+#  line_notification_enabled   :boolean          default(FALSE), not null
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
+#  mealtime_first              :time
 #  name                        :string           default("noname"), not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null


### PR DESCRIPTION
## 概要
ユーザーの設定した時間に当日の食事内容をLINEで通知するrakeタスクを作成した。
現状このrakeタスクを実行するのにどれほどサーバーに負荷がかかるかがわかりかねるため、
設定可能な時間は30分毎に留めている。
今後場合により10分毎に設定できるよう変更する可能性もある。

また、合わせてマイページのアカウント情報設定タブ内にまず通知機能を使用するか、次に使用するならば時間を設定できるフォームを作成。
<br />


## チェックリスト
- [x] `mealtime_first`カラムの追加
- [x] `line_notification_enabled`カラムの追加
- [x] バリデーションの追加
- [x] コントローラーの作成
- [x] ルーティングの定義
- [x] フォームの作成
- [x] rakeタスクの作成
- [x] リントチェック
- [x] 動作確認

<br />

closes #52 
