### PR TITLE
アカウント情報編集機能を作成

### DIFF
--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -10,7 +10,7 @@ module Admin
     def new; end
 
     def create
-      @user = login(params[:email], params[:password])
+      @user = login(params[:name], params[:password])
 
       if @user
         redirect_to admin_root_path, notice: "ログイン成功"

--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -6,7 +6,7 @@ module Api
       skip_before_action :require_login
 
       def create
-        @user = login(params[:email], params[:password])
+        @user = login(params[:name], params[:password])
 
         if @user
           render json: { id: @user.id }

--- a/app/controllers/api/v1/user_accounts_controller.rb
+++ b/app/controllers/api/v1/user_accounts_controller.rb
@@ -19,7 +19,7 @@ module Api
       private
 
         def user_params
-          params.require(:user).permit(:line_notification_enabled, :mealtime_first)
+          params.require(:user).permit(:name, :email, :line_notification_enabled, :mealtime_first)
         end
     end
   end

--- a/app/controllers/line/authentications_controller.rb
+++ b/app/controllers/line/authentications_controller.rb
@@ -10,7 +10,7 @@ module Line
 
     def create
       # 連携手順3. 自社サービスのユーザーIDを取得する
-      login_user = login(params[:email], params[:password])
+      login_user = login(params[:name], params[:password])
 
       if login_user
         link_token = params[:link_token]

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -22,6 +22,6 @@ export default {
 
 <style scoped>
 #app {
-  background-color: #f5f5f6;
+  background-color: #2C4C6B;
 }
 </style>

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -22,6 +22,6 @@ export default {
 
 <style scoped>
 #app {
-  background-color: #2C4C6B;
+  background-color: #2c4c6b;
 }
 </style>

--- a/app/javascript/components/pages/LoginPage.vue
+++ b/app/javascript/components/pages/LoginPage.vue
@@ -15,16 +15,16 @@
           </template>
           <validation-provider
             v-slot="{ errors }"
-            name="メールアドレス"
-            rules="email|required"
+            name="ユーザーネーム"
+            rules="required"
           >
             <v-text-field
-              v-model="email"
+              v-model="name"
               :error-messages="errors"
               color="base"
               dark
-              type="email"
-              label="メールアドレス"
+              type="name"
+              label="ユーザーネーム"
               required
             />
           </validation-provider>
@@ -57,7 +57,7 @@
 export default {
   data() {
     return {
-      email: '',
+      name: '',
       password: '',
       railsErrors: {
         show: false,
@@ -70,7 +70,7 @@ export default {
     loginUser() {
       this.axios
         .post('api/v1/authentication', {
-          email: this.email,
+          name: this.name,
           password: this.password,
         })
         .then((response) => {

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -134,7 +134,7 @@ export default {
 }
 
 .tab-item {
-  background-color: #f5f5f6;
+  background-color: #2C4C6B;
   padding: 30px 25px;
 }
 </style>

--- a/app/javascript/components/pages/MyPage.vue
+++ b/app/javascript/components/pages/MyPage.vue
@@ -134,7 +134,7 @@ export default {
 }
 
 .tab-item {
-  background-color: #2C4C6B;
+  background-color: #2c4c6b;
   padding: 30px 25px;
 }
 </style>

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -1,128 +1,135 @@
 <template>
-    <validation-observer ref="observer" v-slot="{ handleSubmit }">
-      <v-form @submit.prevent="handleSubmit(updateAccount)" id="account-form">
-        <template v-if="railsErrors.show">
-          <v-alert class="text-center" dense type="error">
-            <template v-for="e in railsErrors.errorMessages">
-              <p :key="e">{{ e }}</p>
-            </template>
-          </v-alert>
-        </template>
+  <validation-observer ref="observer" v-slot="{ handleSubmit }">
+    <v-form id="account-form" @submit.prevent="handleSubmit(updateAccount)">
+      <template v-if="railsErrors.show">
+        <v-alert class="text-center" dense type="error">
+          <template v-for="e in railsErrors.errorMessages">
+            <p :key="e">{{ e }}</p>
+          </template>
+        </v-alert>
+      </template>
 
-        <validation-provider
-          v-slot="{ errors }"
-          name="ユーザーネーム"
-          rules="required"
-        >
-          <v-text-field
-            v-model="user.name"
-            :error-messages="errors"
+      <validation-provider
+        v-slot="{ errors }"
+        name="ユーザーネーム"
+        rules="required"
+      >
+        <v-text-field
+          v-model="user.name"
+          :error-messages="errors"
+          color="base"
+          dark
+          dense
+          type="text"
+          label="ユーザーネーム"
+          prepend-icon="mdi-account-outline"
+          required
+          class="form-item"
+        />
+      </validation-provider>
+      <validation-provider
+        v-slot="{ errors }"
+        name="メールアドレス"
+        rules="email|required"
+      >
+        <v-text-field
+          v-model="user.email"
+          :error-messages="errors"
+          color="base"
+          dark
+          dense
+          type="email"
+          label="メールアドレス"
+          prepend-icon="mdi-email-outline"
+          required
+          class="form-item"
+        />
+      </validation-provider>
+      <div class="form-item line-form">
+        <div class="line-form-switch">
+          <v-switch
+            v-model="user.line_notification_enabled"
             color="base"
             dark
             dense
-            type="text"
-            label="ユーザーネーム"
-            prepend-icon="mdi-account-outline"
-            required
-            class="form-item"
-          />
-        </validation-provider>
-        <validation-provider
-          v-slot="{ errors }"
-          name="メールアドレス"
-          rules="email|required"
-        >
-          <v-text-field
-            v-model="user.email"
-            :error-messages="errors"
-            color="base"
-            dark
-            dense
-            type="email"
-            label="メールアドレス"
-            prepend-icon="mdi-email-outline"
-            required
-            class="form-item"
-          />
-        </validation-provider>
-        <div class="form-item line-form">
-          <div class="line-form-switch">
-            <v-switch
-              v-model="user.line_notification_enabled"
-              color="base"
-              dark
-              dense
-              flat
-              inset
-              label="LINE通知機能"
-            ></v-switch>
-          </div>
-          <div v-show="user.line_notification_enabled">
-            <v-dialog
-              ref="dialog"
-              v-model="timePicker"
-              :return-value.sync="user.mealtime_first"
-            >
-              <template #activator="{ on, attrs }">
-                <v-text-field
-                  v-model="user.mealtime_first"
-                  label="食事内容を通知する時間"
-                  color="base"
-                  dark
-                  dense
-                  prepend-icon="mdi-clock-time-four-outline"
-                  readonly
-                  v-bind="attrs"
-                  v-on="on"
-                ></v-text-field>
-              </template>
-              <v-time-picker
-                v-show="timePicker"
+            flat
+            inset
+            label="LINE通知機能"
+          ></v-switch>
+        </div>
+        <div v-show="user.line_notification_enabled">
+          <v-dialog
+            ref="dialog"
+            v-model="timePicker"
+            :return-value.sync="user.mealtime_first"
+          >
+            <template #activator="{ on, attrs }">
+              <v-text-field
                 v-model="user.mealtime_first"
-                :allowed-hours="allowedHours"
-                :allowed-minutes="allowedMinutes"
-                color="primary"
-                flat
-                format="24hr"
-                min="7:00"
-                max="23:00"
-                scrollable
-                full-width
+                label="食事内容を通知する時間"
+                color="base"
+                dark
+                dense
+                prepend-icon="mdi-clock-time-four-outline"
+                readonly
+                v-bind="attrs"
+                v-on="on"
+              ></v-text-field>
+            </template>
+            <v-time-picker
+              v-show="timePicker"
+              v-model="user.mealtime_first"
+              :allowed-hours="allowedHours"
+              :allowed-minutes="allowedMinutes"
+              color="primary"
+              flat
+              format="24hr"
+              min="7:00"
+              max="23:00"
+              scrollable
+              full-width
+            >
+              <v-btn
+                outlined
+                small
+                tile
+                clor="primary"
+                @click="timePicker = false"
               >
-                <v-btn
-                  outlined
-                  small
-                  tile
-                  clor="primary"
-                  @click="timePicker = false"
-                >
-                  Cancel
-                </v-btn>
-                <v-btn
-                  outlined
-                  small
-                  tile
-                  color="primary"
-                  @click="$refs.dialog.save(user.mealtime_first)"
-                >
-                  OK
-                </v-btn>
-              </v-time-picker>
-            </v-dialog>
-            <div class="base--text text-caption">
-              ※サーバーへの負荷などの要因により通知のタイミングが数分ほど遅れる場合があります
-            </div>
-            <div>
-              <a href="https://lin.ee/czet3Px">
-                <img src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png" alt="友だち追加" height="36" border="0">
-              </a>
-            </div>
+                Cancel
+              </v-btn>
+              <v-btn
+                outlined
+                small
+                tile
+                color="primary"
+                @click="$refs.dialog.save(user.mealtime_first)"
+              >
+                OK
+              </v-btn>
+            </v-time-picker>
+          </v-dialog>
+          <div class="base--text text-caption">
+            ※サーバーへの負荷などの要因により通知のタイミングが数分ほど遅れる場合があります
+          </div>
+          <div>
+            <a href="https://lin.ee/czet3Px">
+              <img
+                src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
+                alt="友だち追加"
+                height="36"
+                border="0"
+              />
+            </a>
           </div>
         </div>
-        <div class="base--text text-caption">
-          ※パスワードの変更は、お手数ですがログインページ下部の「パスワードをリセットする」から行ってください
-        </div>
-        <v-btn type="submit" color="base" outlined tile small width="120">更新</v-btn>
+      </div>
+      <div class="base--text text-caption">
+        ※パスワードの変更は、お手数ですがログインページ下部の「パスワードをリセットする」から行ってください
+      </div>
+      <v-btn type="submit" color="base" outlined tile small width="120"
+        >更新</v-btn
+      >
     </v-form>
   </validation-observer>
 </template>

--- a/app/javascript/components/parts/MyPageAccountForm.vue
+++ b/app/javascript/components/parts/MyPageAccountForm.vue
@@ -1,24 +1,62 @@
 <template>
-  <v-card id="account-form" color="primary" flat tile>
     <validation-observer ref="observer" v-slot="{ handleSubmit }">
-      <v-form @submit.prevent="handleSubmit(updateAccount)">
-        <v-card-text>
-          <template v-if="railsErrors.show">
-            <v-alert class="text-center" dense type="error">
-              <template v-for="e in railsErrors.errorMessages">
-                <p :key="e">{{ e }}</p>
-              </template>
-            </v-alert>
-          </template>
+      <v-form @submit.prevent="handleSubmit(updateAccount)" id="account-form">
+        <template v-if="railsErrors.show">
+          <v-alert class="text-center" dense type="error">
+            <template v-for="e in railsErrors.errorMessages">
+              <p :key="e">{{ e }}</p>
+            </template>
+          </v-alert>
+        </template>
 
-          <v-switch
-            v-model="user.line_notification_enabled"
+        <validation-provider
+          v-slot="{ errors }"
+          name="ユーザーネーム"
+          rules="required"
+        >
+          <v-text-field
+            v-model="user.name"
+            :error-messages="errors"
             color="base"
             dark
             dense
-            flat
-            label="LINE通知機能"
-          ></v-switch>
+            type="text"
+            label="ユーザーネーム"
+            prepend-icon="mdi-account-outline"
+            required
+            class="form-item"
+          />
+        </validation-provider>
+        <validation-provider
+          v-slot="{ errors }"
+          name="メールアドレス"
+          rules="email|required"
+        >
+          <v-text-field
+            v-model="user.email"
+            :error-messages="errors"
+            color="base"
+            dark
+            dense
+            type="email"
+            label="メールアドレス"
+            prepend-icon="mdi-email-outline"
+            required
+            class="form-item"
+          />
+        </validation-provider>
+        <div class="form-item line-form">
+          <div class="line-form-switch">
+            <v-switch
+              v-model="user.line_notification_enabled"
+              color="base"
+              dark
+              dense
+              flat
+              inset
+              label="LINE通知機能"
+            ></v-switch>
+          </div>
           <div v-show="user.line_notification_enabled">
             <v-dialog
               ref="dialog"
@@ -29,16 +67,17 @@
                 <v-text-field
                   v-model="user.mealtime_first"
                   label="食事内容を通知する時間"
-                  prepend-icon="mdi-clock-time-four-outline"
                   color="base"
                   dark
+                  dense
+                  prepend-icon="mdi-clock-time-four-outline"
                   readonly
                   v-bind="attrs"
                   v-on="on"
                 ></v-text-field>
               </template>
               <v-time-picker
-                v-if="timePicker"
+                v-show="timePicker"
                 v-model="user.mealtime_first"
                 :allowed-hours="allowedHours"
                 :allowed-minutes="allowedMinutes"
@@ -71,16 +110,21 @@
               </v-time-picker>
             </v-dialog>
             <div class="base--text text-caption">
-              ※サーバーの負荷などの要因により通知のタイミングが数分ほど遅れる場合があります
+              ※サーバーへの負荷などの要因により通知のタイミングが数分ほど遅れる場合があります
+            </div>
+            <div>
+              <a href="https://lin.ee/czet3Px">
+                <img src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png" alt="友だち追加" height="36" border="0">
+              </a>
             </div>
           </div>
-        </v-card-text>
-        <v-card-actions>
-          <v-btn type="submit" color="base" outlined>更新</v-btn>
-        </v-card-actions>
-      </v-form>
-    </validation-observer>
-  </v-card>
+        </div>
+        <div class="base--text text-caption">
+          ※パスワードの変更は、お手数ですがログインページ下部の「パスワードをリセットする」から行ってください
+        </div>
+        <v-btn type="submit" color="base" outlined tile small width="120">更新</v-btn>
+    </v-form>
+  </validation-observer>
 </template>
 
 <script>
@@ -92,6 +136,7 @@ export default {
         mealtime_first: '',
       },
       timePicker: false,
+      passwordForm: false,
       railsErrors: {
         show: false,
         message: '',
@@ -147,3 +192,22 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+#account-form {
+  text-align: center;
+}
+.form-item {
+  margin-bottom: 30px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.line-form-switch {
+  margin-bottom: 20px;
+}
+
+.v-text-field {
+  max-width: 350px;
+}
+</style>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,7 +147,8 @@ end
 #  birth                       :date
 #  bmr                         :float            default(0.0), not null
 #  crypted_password            :string
-#  email                       :string           default("address@example.com"), not null
+#  email_bidx                  :string           not null
+#  email_ciphertext            :text             not null
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
@@ -169,7 +170,7 @@ end
 # Indexes
 #
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
-#  index_users_on_email                        (email) UNIQUE
+#  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
 #
 # Foreign Keys

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
   scope :wish_line_notice, -> { linked_line.notice_enable.set_mealtime }
 
   # Encryption
+  encrypts :email
+  blind_index :email
   encrypts :line_user_id
   blind_index :line_user_id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,8 @@ class User < ApplicationRecord
 
   def set_account_params
     {
+      name: name,
+      email: email,
       line_notification_enabled: line_notification_enabled,
       mealtime_first: mealtime_first&.strftime('%R')
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ end
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
 #  mealtime_first              :time
-#  name                        :string           default("noname"), not null
+#  name                        :string           not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null
 #  percentage_protein          :float            default(0.2), not null
@@ -174,6 +174,7 @@ end
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
 #  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
+#  index_users_on_name                         (name) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   validates_with PfcValidator
 
   with_options presence: true do
-    validates :name, length: { maximum: 50 }
+    validates :name, length: { maximum: 50 }, uniqueness: { case_sensitive: true }
     validates :email, uniqueness: { case_sensitive: false }
     validates :role
     validates :gender

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -3,8 +3,8 @@
     <h4>管理者用ログイン</h4>
     <%= form_with url: admin_login_path, local: true do |f| %>
       <div class="admin-login-form-group">
-        <%= f.label :email, class: "admin-login-form-label" %><br>
-        <%= f.email_field :email, class: "admin-login-form-text" %>
+        <%= f.label :name, class: "admin-login-form-label" %><br>
+        <%= f.text_field :name, class: "admin-login-form-text" %>
       </div>
       <div class="admin-login-form-group">
         <%= f.label :password, class: "admin-login-form-label" %><br>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -9,10 +9,6 @@
         <%= f.search_field :name_cont, class: "admin-form-text" %>
       </div>
       <div class="admin-search-form">
-        <%= f.label :email_cont, 'メールアドレス', class: "admin-form-label" %>
-        <%= f.search_field :email_cont, class: "admin-form-text" %>
-      </div>
-      <div class="admin-search-form">
         <%= f.label :gender_eq, '性別', class: "admin-form-label" %>
         <%= f.select :gender_eq, User.genders_i18n.invert.map{|key, value| [key, User.genders[value]]}, { include_blank: '未選択' }, class: "admin-form-select" %>
       </div>

--- a/app/views/line/authentications/link.html.erb
+++ b/app/views/line/authentications/link.html.erb
@@ -3,10 +3,11 @@
 
   <div class="line-login-form">
     <h4>LINE連携用ログイン</h4>
+    <!-- TODO: フォームは管理者用ログインと共有にする -->
     <%= form_with url: line_link_path, local: true do |f| %>
       <div class="line-login-form-group">
-        <%= f.label :email, class: "line-login-form-label" %><br>
-        <%= f.email_field :email, class: "line-login-form-text" %>
+        <%= f.label :name, class: "line-login-form-label" %><br>
+        <%= f.text_field :name, class: "line-login-form-text" %>
       </div>
       <div class="line-login-form-group">
         <%= f.label :password, class: "line-login-form-label" %><br>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :line_nonce, :line_user_id]
+Rails.application.config.filter_parameters += [:email, :password, :line_nonce, :line_user_id]

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -248,7 +248,7 @@ Rails.application.config.sorcery.configure do |config|
     # Specify username attributes, for example: [:username, :email].
     # Default: `[:email]`
     #
-    # user.username_attribute_names =
+    user.username_attribute_names = [:name]
 
     # Change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`

--- a/db/migrate/20211026074819_add_email_ciphertext_to_users.rb
+++ b/db/migrate/20211026074819_add_email_ciphertext_to_users.rb
@@ -1,0 +1,10 @@
+class AddEmailCiphertextToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :email_ciphertext, :text, null: false
+    add_column :users, :email_bidx, :string, null: false
+    add_index :users, :email_bidx, unique: true
+
+    remove_index :users, :email
+    remove_column :users, :email, :string
+  end
+end

--- a/db/migrate/20211026130203_add_index_to_users_name.rb
+++ b/db/migrate/20211026130203_add_index_to_users_name.rb
@@ -1,0 +1,6 @@
+class AddIndexToUsersName < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :users, :name, nil
+    add_index :users, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_074819) do
+ActiveRecord::Schema.define(version: 2021_10_26_130203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_074819) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", default: "noname", null: false
+    t.string "name", null: false
     t.string "crypted_password"
     t.string "salt"
     t.integer "role", default: 0, null: false
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_074819) do
     t.index ["dietary_reference_intake_id"], name: "index_users_on_dietary_reference_intake_id"
     t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["line_user_id_bidx"], name: "index_users_on_line_user_id_bidx", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
   end
 
   add_foreign_key "foods", "food_categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_062812) do
+ActiveRecord::Schema.define(version: 2021_10_26_074819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,7 +126,6 @@ ActiveRecord::Schema.define(version: 2021_10_23_062812) do
 
   create_table "users", force: :cascade do |t|
     t.string "name", default: "noname", null: false
-    t.string "email", default: "address@example.com", null: false
     t.string "crypted_password"
     t.string "salt"
     t.integer "role", default: 0, null: false
@@ -146,8 +145,10 @@ ActiveRecord::Schema.define(version: 2021_10_23_062812) do
     t.string "line_user_id_bidx"
     t.time "mealtime_first"
     t.boolean "line_notification_enabled", default: false, null: false
+    t.text "email_ciphertext", null: false
+    t.string "email_bidx", null: false
     t.index ["dietary_reference_intake_id"], name: "index_users_on_dietary_reference_intake_id"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["line_user_id_bidx"], name: "index_users_on_line_user_id_bidx", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,7 +22,7 @@ end
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
 #  mealtime_first              :time
-#  name                        :string           default("noname"), not null
+#  name                        :string           not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null
 #  percentage_protein          :float            default(0.2), not null
@@ -38,6 +38,7 @@ end
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
 #  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
+#  index_users_on_name                         (name) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,7 +13,8 @@ end
 #  birth                       :date
 #  bmr                         :float            default(0.0), not null
 #  crypted_password            :string
-#  email                       :string           default("address@example.com"), not null
+#  email_bidx                  :string           not null
+#  email_ciphertext            :text             not null
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
@@ -35,7 +36,7 @@ end
 # Indexes
 #
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
-#  index_users_on_email                        (email) UNIQUE
+#  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
 #
 # Foreign Keys

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,8 @@ end
 #  birth                       :date
 #  bmr                         :float            default(0.0), not null
 #  crypted_password            :string
-#  email                       :string           default("address@example.com"), not null
+#  email_bidx                  :string           not null
+#  email_ciphertext            :text             not null
 #  gender                      :integer          default("female"), not null
 #  height                      :integer          default(0), not null
 #  line_nonce                  :string
@@ -36,7 +37,7 @@ end
 # Indexes
 #
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
-#  index_users_on_email                        (email) UNIQUE
+#  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
 #
 # Foreign Keys

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,7 +23,7 @@ end
 #  line_user_id_bidx           :string
 #  line_user_id_ciphertext     :text
 #  mealtime_first              :time
-#  name                        :string           default("noname"), not null
+#  name                        :string           not null
 #  percentage_carbohydrate     :float            default(0.6), not null
 #  percentage_fat              :float            default(0.2), not null
 #  percentage_protein          :float            default(0.2), not null
@@ -39,6 +39,7 @@ end
 #  index_users_on_dietary_reference_intake_id  (dietary_reference_intake_id)
 #  index_users_on_email_bidx                   (email_bidx) UNIQUE
 #  index_users_on_line_user_id_bidx            (line_user_id_bidx) UNIQUE
+#  index_users_on_name                         (name) UNIQUE
 #
 # Foreign Keys
 #


### PR DESCRIPTION
## 概要
ユーザーのアカウント情報を編集できる機能を作成した。
編集可能な項目として以下を追加した。
- ユーザー名
- メールアドレス
- （LINE友達追加ボタンの追加）

また、emailカラムのLockboxによる暗号化の適用も合わせて行った。
これに伴い、`sorcery`によるログインに使用するカラムを`email`から
`name`に変更。
そして`name`カラムに一意性制約を追加、デフォルト値を削除した。


なお、`email`は基本的にパスワードリセットの際と、緊急時の連絡
などにのみ使用することとする。


## チェックリスト
- [x] `user_accounts_controller`への追記
- [x] フォームの追加作成
- [x] emailカラムのLockbox適用
- [x] リントチェック
- [x] 動作確認
<br />

closes #55 