### PR TITLE
ログイン後即ログインすると発生するエラーを解消

### DIFF
--- a/app/javascript/components/commons/FooterMenuItemsAfterLogin.vue
+++ b/app/javascript/components/commons/FooterMenuItemsAfterLogin.vue
@@ -64,7 +64,10 @@ export default {
           });
 
           this.$router.push({ name: 'TopPage' });
-          this.$router.go({path: this.$router.currentRoute.path, force: true})
+          this.$router.go({
+            path: this.$router.currentRoute.path,
+            force: true,
+          });
         })
         .catch((error) => {
           let e = error.response;

--- a/app/javascript/components/commons/FooterMenuItemsAfterLogin.vue
+++ b/app/javascript/components/commons/FooterMenuItemsAfterLogin.vue
@@ -64,6 +64,7 @@ export default {
           });
 
           this.$router.push({ name: 'TopPage' });
+          this.$router.go({path: this.$router.currentRoute.path, force: true})
         })
         .catch((error) => {
           let e = error.response;


### PR DESCRIPTION
## 概要
ログアウト後、ページをリロードせずに続けてログイン処理を行うと、`ActionController::InvalidAuthenticityToken`が発生していた。

これは恐らく、postリクエストに使用するcsrf_tokenは本来セッション毎に再生成されるのだが、それが何らかの理由により正常に動作しないために発生していると思われる。

そのため現時点での解決策としては、簡単かつ確実な、「ログアウト時に自動でページをリロードさせる処理を追加する」手段をとった。
が、今後もっと根本的な解決策が判明した場合は改めて修正を行う。
<br />


## チェックリスト
- [x] エラー修正
- [x] リントチェック
- [x] 動作確認

<br />

closes #37
