### PR TITLE
新規ユーザー登録ページに性別と生年月日の入力欄を追加#66

### DIFF
--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -3,10 +3,14 @@
 module Api
   module V1
     class RegistrationsController < Api::V1::BaseController
+      include UsersDri
       skip_before_action :require_login
 
       def create
         user = User.new(user_params)
+
+        dri = set_reference_intake(user)
+        user.dietary_reference_intake_id = dri.id
 
         if user.save
           head :ok
@@ -18,7 +22,7 @@ module Api
       private
 
         def user_params
-          params.require(:user).permit(:name, :email, :password, :password_confirmation)
+          params.require(:user).permit(:name, :email, :gender, :birth, :password, :password_confirmation)
         end
     end
   end

--- a/app/controllers/api/v1/users_dietary_reference_intakes_controller.rb
+++ b/app/controllers/api/v1/users_dietary_reference_intakes_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class UsersDietaryReferenceIntakesController < Api::V1::BaseController
+      include UsersDri
       before_action :set_user
 
       def update
@@ -22,32 +23,6 @@ module Api
 
         def set_user
           @user = User.find(current_user.id)
-        end
-
-        def set_reference_intake(user)
-          dri = witch_gender?(user)
-          check_age_range(user, dri)
-        end
-
-        def witch_gender?(user)
-          if user.gender == 'female'
-            DietaryReferenceIntake.for_female
-          else
-            DietaryReferenceIntake.for_maele
-          end
-        end
-
-        def check_age_range(user, dri)
-          age = user.calc_age
-
-          case age
-          when 18..29
-            dri.for_eighteen_to_twentynine
-          when 30..49
-            dri.for_thirty_to_fortynine
-          when 50..64
-            dri.for_fifty_to_sixtyfour
-          end
         end
     end
   end

--- a/app/controllers/concerns/api/users_dri.rb
+++ b/app/controllers/concerns/api/users_dri.rb
@@ -1,32 +1,36 @@
-module Api::UsersDri
-  extend ActiveSupport::Concern
+# frozen_string_literal: true
 
-  def set_reference_intake(user)
-    by_gender = witch_gender?(user)
-    check_age_range(user, by_gender)
+module Api
+  module UsersDri
+    extend ActiveSupport::Concern
+
+    def set_reference_intake(user)
+      by_gender = witch_gender?(user)
+      check_age_range(user, by_gender)
+    end
+
+    private
+
+      def witch_gender?(user)
+        case user.gender
+        when 'female'
+          DietaryReferenceIntake.for_female
+        when 'male'
+          DietaryReferenceIntake.for_male
+        end
+      end
+
+      def check_age_range(user, dri)
+        age = user.calc_age
+
+        case age
+        when 18..29
+          dri.for_eighteen_to_twentynine
+        when 30..49
+          dri.for_thirty_to_fortynine
+        when 50..64
+          dri.for_fifty_to_sixtyfour
+        end
+      end
   end
-
-  private
-
-    def witch_gender?(user)
-      case user.gender
-      when 'female'
-        DietaryReferenceIntake.for_female
-      when 'male'
-        DietaryReferenceIntake.for_male
-      end
-    end
-
-    def check_age_range(user, dri)
-      age = user.calc_age
-
-      case age
-      when 18..29
-        dri.for_eighteen_to_twentynine
-      when 30..49
-        dri.for_thirty_to_fortynine
-      when 50..64
-        dri.for_fifty_to_sixtyfour
-      end
-    end
 end

--- a/app/controllers/concerns/api/users_dri.rb
+++ b/app/controllers/concerns/api/users_dri.rb
@@ -1,0 +1,32 @@
+module Api::UsersDri
+  extend ActiveSupport::Concern
+
+  def set_reference_intake(user)
+    by_gender = witch_gender?(user)
+    check_age_range(user, by_gender)
+  end
+
+  private
+
+    def witch_gender?(user)
+      case user.gender
+      when 'female'
+        DietaryReferenceIntake.for_female
+      when 'male'
+        DietaryReferenceIntake.for_male
+      end
+    end
+
+    def check_age_range(user, dri)
+      age = user.calc_age
+
+      case age
+      when 18..29
+        dri.for_eighteen_to_twentynine
+      when 30..49
+        dri.for_thirty_to_fortynine
+      when 50..64
+        dri.for_fifty_to_sixtyfour
+      end
+    end
+end

--- a/app/javascript/components/pages/RegisterPage.vue
+++ b/app/javascript/components/pages/RegisterPage.vue
@@ -3,109 +3,111 @@
     <div class="text-h6 base--text">新規ユーザー登録</div>
     <validation-observer ref="observer" v-slot="{ handleSubmit }">
       <v-form @submit.prevent="handleSubmit(createUser)">
-          <template v-if="railsErrors.show">
-            <v-alert class="text-center" dense type="error">
-              <template v-for="e in railsErrors.errorMessages">
-                <p :key="e">{{ e }}</p>
-              </template>
-            </v-alert>
-          </template>
-          <validation-provider
-            v-slot="{ errors }"
-            name="ユーザーネーム"
-            rules="required"
-          >
-            <v-text-field
-              v-model="user.name"
-              :error-messages="errors"
-              color="base"
-              dark
-              type="text"
-              label="ユーザーネーム"
-              required
-            />
-          </validation-provider>
-          <validation-provider
-            v-slot="{ errors }"
-            name="メールアドレス"
-            rules="email|required"
-          >
-            <v-text-field
-              v-model="user.email"
-              :error-messages="errors"
-              color="base"
-              dark
-              type="email"
-              label="メールアドレス"
-              required
-            />
-          </validation-provider>
-          <v-radio-group
-            v-model="user.gender"
-            label="性別"
-            dark
-            row
-            mandatory
-            class="radio-group"
-          >
-            <div class="radio-btns">
-              <v-radio color="base" label="女性" value="female" />
-              <v-radio color="base" label="男性" value="male" />
-            </div>
-          </v-radio-group>
-          <v-menu v-model="birthInput" :close-on-content-click="false">
-            <template #activator="{ on }">
-              <validation-provider
-                v-slot="{ errors }"
-                name="生年月日"
-                rules="required|abailable_age"
-              >
-                <v-text-field
-                  v-model="user.birth"
-                  :error-messages="errors"
-                  color="base"
-                  dark
-                  label="生年月日"
-                  type="date"
-                  readonly
-                  v-on="on"
-                />
-              </validation-provider>
+        <template v-if="railsErrors.show">
+          <v-alert class="text-center" dense type="error">
+            <template v-for="e in railsErrors.errorMessages">
+              <p :key="e">{{ e }}</p>
             </template>
-            <v-date-picker v-model="user.birth" @input="birthInput = false" />
-          </v-menu>
-          <validation-provider
-            v-slot="{ errors }"
-            name="パスワード"
-            rules="alpha_num|min:5|required"
-            vid="confirmation"
-          >
-            <v-text-field
-              v-model="user.password"
-              :error-messages="errors"
-              color="base"
-              dark
-              type="password"
-              label="パスワード"
-              required
-            />
-          </validation-provider>
-          <validation-provider
-            v-slot="{ errors }"
-            name="パスワード（確認）"
-            rules="confirmed:confirmation|required"
-          >
-            <v-text-field
-              v-model="user.password_confirmation"
-              :error-messages="errors"
-              color="base"
-              dark
-              type="password"
-              label="パスワード（確認）"
-              required
-            />
-          </validation-provider>
-          <v-btn type="submit" color="base" outlined tile small width="120">登録</v-btn>
+          </v-alert>
+        </template>
+        <validation-provider
+          v-slot="{ errors }"
+          name="ユーザーネーム"
+          rules="required"
+        >
+          <v-text-field
+            v-model="user.name"
+            :error-messages="errors"
+            color="base"
+            dark
+            type="text"
+            label="ユーザーネーム"
+            required
+          />
+        </validation-provider>
+        <validation-provider
+          v-slot="{ errors }"
+          name="メールアドレス"
+          rules="email|required"
+        >
+          <v-text-field
+            v-model="user.email"
+            :error-messages="errors"
+            color="base"
+            dark
+            type="email"
+            label="メールアドレス"
+            required
+          />
+        </validation-provider>
+        <v-radio-group
+          v-model="user.gender"
+          label="性別"
+          dark
+          row
+          mandatory
+          class="radio-group"
+        >
+          <div class="radio-btns">
+            <v-radio color="base" label="女性" value="female" />
+            <v-radio color="base" label="男性" value="male" />
+          </div>
+        </v-radio-group>
+        <v-menu v-model="birthInput" :close-on-content-click="false">
+          <template #activator="{ on }">
+            <validation-provider
+              v-slot="{ errors }"
+              name="生年月日"
+              rules="required|abailable_age"
+            >
+              <v-text-field
+                v-model="user.birth"
+                :error-messages="errors"
+                color="base"
+                dark
+                label="生年月日"
+                type="date"
+                readonly
+                v-on="on"
+              />
+            </validation-provider>
+          </template>
+          <v-date-picker v-model="user.birth" @input="birthInput = false" />
+        </v-menu>
+        <validation-provider
+          v-slot="{ errors }"
+          name="パスワード"
+          rules="alpha_num|min:5|required"
+          vid="confirmation"
+        >
+          <v-text-field
+            v-model="user.password"
+            :error-messages="errors"
+            color="base"
+            dark
+            type="password"
+            label="パスワード"
+            required
+          />
+        </validation-provider>
+        <validation-provider
+          v-slot="{ errors }"
+          name="パスワード（確認）"
+          rules="confirmed:confirmation|required"
+        >
+          <v-text-field
+            v-model="user.password_confirmation"
+            :error-messages="errors"
+            color="base"
+            dark
+            type="password"
+            label="パスワード（確認）"
+            required
+          />
+        </validation-provider>
+        <v-btn type="submit" color="base" outlined tile small width="120"
+          >登録</v-btn
+        >
       </v-form>
     </validation-observer>
   </v-container>

--- a/app/javascript/components/pages/RegisterPage.vue
+++ b/app/javascript/components/pages/RegisterPage.vue
@@ -1,11 +1,8 @@
 <template>
-  <v-card id="register-form" color="primary" flat tile>
-    <v-card-title>
-      <div class="text-h6 base--text">新規ユーザー登録</div>
-    </v-card-title>
+  <v-container id="register-form">
+    <div class="text-h6 base--text">新規ユーザー登録</div>
     <validation-observer ref="observer" v-slot="{ handleSubmit }">
       <v-form @submit.prevent="handleSubmit(createUser)">
-        <v-card-text>
           <template v-if="railsErrors.show">
             <v-alert class="text-center" dense type="error">
               <template v-for="e in railsErrors.errorMessages">
@@ -43,6 +40,40 @@
               required
             />
           </validation-provider>
+          <v-radio-group
+            v-model="user.gender"
+            label="性別"
+            dark
+            row
+            mandatory
+            class="radio-group"
+          >
+            <div class="radio-btns">
+              <v-radio color="base" label="女性" value="female" />
+              <v-radio color="base" label="男性" value="male" />
+            </div>
+          </v-radio-group>
+          <v-menu v-model="birthInput" :close-on-content-click="false">
+            <template #activator="{ on }">
+              <validation-provider
+                v-slot="{ errors }"
+                name="生年月日"
+                rules="required|abailable_age"
+              >
+                <v-text-field
+                  v-model="user.birth"
+                  :error-messages="errors"
+                  color="base"
+                  dark
+                  label="生年月日"
+                  type="date"
+                  readonly
+                  v-on="on"
+                />
+              </validation-provider>
+            </template>
+            <v-date-picker v-model="user.birth" @input="birthInput = false" />
+          </v-menu>
           <validation-provider
             v-slot="{ errors }"
             name="パスワード"
@@ -74,13 +105,10 @@
               required
             />
           </validation-provider>
-        </v-card-text>
-        <v-card-actions>
-          <v-btn type="submit" color="base" outlined>登録</v-btn>
-        </v-card-actions>
+          <v-btn type="submit" color="base" outlined tile small width="120">登録</v-btn>
       </v-form>
     </validation-observer>
-  </v-card>
+  </v-container>
 </template>
 
 <script>
@@ -90,6 +118,8 @@ export default {
       user: {
         name: '',
         email: '',
+        gender: '',
+        birth: '',
         password: '',
         password_confirmation: '',
       },
@@ -137,10 +167,19 @@ export default {
 
 <style scoped>
 #register-form {
-  margin: 30px 40px;
+  padding: 40px 25px 30px 25px;
+  text-align: center;
 }
 
 .actions {
   text-align: center;
+}
+
+.v-text-field {
+  max-width: 350px;
+}
+
+.radio-btns {
+  display: flex;
 }
 </style>

--- a/app/javascript/components/parts/MyPageWithdrawalForm.vue
+++ b/app/javascript/components/parts/MyPageWithdrawalForm.vue
@@ -94,6 +94,10 @@ export default {
           });
 
           this.$router.push({ name: 'TopPage' });
+          this.$router.go({
+            path: this.$router.currentRoute.path,
+            force: true,
+          });
         })
         .catch((e) => {
           console.error(e.response.status);

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -20,21 +20,20 @@ const router = new VueRouter({
       component: TopPage,
       name: 'TopPage',
       meta: { isPublic: true },
-      children: [
-        {
-          path: 'register',
-          component: RegisterPage,
-          name: 'RegisterPage',
-          meta: { isPublic: true },
-        },
-        {
-          path: 'login',
-          component: LoginPage,
-          name: 'LoginPage',
-          meta: { isPublic: true },
-        },
-      ],
     },
+    {
+      path: '/register',
+      component: RegisterPage,
+      name: 'RegisterPage',
+      meta: { isPublic: true },
+    },
+    {
+      path: '/login',
+      component: LoginPage,
+      name: 'LoginPage',
+      meta: { isPublic: true },
+    },
+    // 以下、要ログイン
     {
       path: '/home',
       component: HomePage,

--- a/app/models/dietary_reference_intake.rb
+++ b/app/models/dietary_reference_intake.rb
@@ -9,7 +9,7 @@ class DietaryReferenceIntake < ApplicationRecord
 
   # Scopes
   scope :for_female, -> { where(gender: 'female') }
-  scope :for_maele, -> { where(gender: 'male') }
+  scope :for_male, -> { where(gender: 'male') }
 
   # Validations
   with_options presence: true do


### PR DESCRIPTION
## 概要
ユーザーの新規作成時にDRIの設定も同時に必要になったため、新規ユーザー登録ページに性別と生年月日のフォームを追加し、`registrations_controller`の`permit`の追記も行った。

なお、`users_dietary_reference_intakes_controller`とで共通の処理が使用されるため、それらをconcernsに切り出し共有した。

<br />


## チェックリスト
- [x] コントローラーへの追記
- [x] フォームの追加
- [x] リントチェック
- [x] 動作確認


<br />

closes #66 
