### PR TITLE
トライアル機能の簡略化

### DIFF
--- a/app/controllers/api/v1/trials_controller.rb
+++ b/app/controllers/api/v1/trials_controller.rb
@@ -8,11 +8,11 @@ module Api
       include DriSetable
 
       def create
+        age = params[:age].to_i
         gender = params[:gender]
-        age = calc_age(params[:birth])
 
         # BMR算出
-        bmr = calc_bmr(age, gender, params[:weight], params[:height]).floor
+        bmr = calc_bmr(age, gender)
         pfc = calc_amount_pfc(bmr)
 
         # DRI選出
@@ -31,18 +31,41 @@ module Api
       private
 
         def trial_params
-          params.permit(:gender, :birth, :height, :weight)
+          params.permit(:age, :gender)
         end
 
         def calc_age(birth)
           (Time.zone.today.strftime("%Y%m%d").to_i - birth.to_date.strftime("%Y%m%d").to_i) / 10_000
         end
 
-        def calc_bmr(age, gender, weight, height)
+        def calc_bmr(age, gender)
+          # 計算式を用いず、日本人の食事摂取基準（2020年版）を参照したおおよその値
           if gender == 'female'
-            (0.0481 * weight + 0.0234 * height - 0.0138 * age - 0.9708) * 1000 / 4.186
+            calc_female_bmr(age)
           else
-            (0.0481 * weight + 0.0234 * height - 0.0138 * age - 0.4235) * 1000 / 4.186
+            calc_male_bmr(age)
+          end
+        end
+
+        def calc_female_bmr(age)
+          case age
+          when 18..29
+            1700
+          when 30..49
+            1750
+          when 50..64
+            1650
+          end
+        end
+
+        def calc_male_bmr(age)
+          case age
+          when 18..29
+            2300
+          when 30..49
+            2300
+          when 50..64
+            2200
           end
         end
 

--- a/app/javascript/components/pages/TopPage.vue
+++ b/app/javascript/components/pages/TopPage.vue
@@ -124,7 +124,7 @@
               ブラウザバック、またはページをリロードするとフォームの入力内容はリセットされます。
             </div>
           </div>
-          <bmr-form class="my-8 mx-7" @click="createTrialSuggestion()" />
+          <trial-bmr-form class="my-8 mx-7" @click="createTrialSuggestion" />
         </v-col>
         <!-- Step.1 ここまで -->
 
@@ -193,13 +193,13 @@
 </template>
 
 <script>
-import BmrForm from '../parts/BmrForm';
+import TrialBmrForm from '../parts/TrialBmrForm';
 import FoodCard from '../parts/FoodCard';
 import NutrientsAchievement from '../parts/NutrientsAchievement';
 
 export default {
   components: {
-    BmrForm,
+    TrialBmrForm,
     FoodCard,
     NutrientsAchievement,
   },
@@ -347,9 +347,11 @@ export default {
     },
   },
   methods: {
-    createTrialSuggestion() {
+    createTrialSuggestion(...args) {
+      // レスト構文
+      const [age, gender] = args;
       this.axios
-        .post('/api/v1/trials', this.$store.state.bmrParams.user)
+        .post('/api/v1/trials', { age: age, gender: gender })
         .then((res) => {
           console.log(res.status);
           const r = res.data;
@@ -479,8 +481,5 @@ export default {
   border-top: 1px solid rgb(245, 245, 246);
   border-left: 1px solid rgb(245, 245, 246);
   border-right: 1px solid rgb(245, 245, 246);
-}
-
-.trial-title-text {
 }
 </style>

--- a/app/javascript/components/parts/TrialBmrForm.vue
+++ b/app/javascript/components/parts/TrialBmrForm.vue
@@ -1,0 +1,203 @@
+<template>
+  <div id="bmr-form">
+    <validation-observer ref="observer" v-slot="{ handleSubmit }">
+      <v-form @submit.prevent="handleSubmit(submit)">
+        <template v-if="railsErrors.show">
+          <template v-for="e in railsErrors.errorMessages">
+            <v-alert
+              :key="e"
+              class="text-center text-body-2 text-sm-body-1"
+              dense
+              type="error"
+            >
+              {{ e }}
+            </v-alert>
+          </template>
+        </template>
+
+        <v-radio-group
+          v-model="gender"
+          label="性別"
+          dark
+          row
+          mandatory
+          hide-details
+          class="form-item raido-btn-outline pl-5 py-1 mb-3"
+        >
+          <v-radio
+            color="accent"
+            label="女性"
+            value="female"
+            class="radio-btn ma-1"
+          />
+          <v-radio
+            color="accent"
+            label="男性"
+            value="male"
+            class="radio-btn ma-1"
+          />
+        </v-radio-group>
+        <v-radio-group
+          v-model="age"
+          label="年齢"
+          dark
+          row
+          mandatory
+          hide-details
+          class="form-item raido-btn-outline gender pl-5 py-1 mb-7"
+        >
+          <div class="d-flex flex-column">
+            <v-radio
+              color="accent"
+              label="18歳~20代"
+              value="20"
+              class="radio-btn ma-1"
+            />
+            <v-radio
+              color="accent"
+              label="30~40代"
+              value="30"
+              class="radio-btn ma-1"
+            />
+            <v-radio
+              color="accent"
+              label="50代~64歳"
+              value="50"
+              class="radio-btn ma-1"
+            />
+          </div>
+        </v-radio-group>
+
+        <div class="result d-flex align-center mx-auto pa-0">
+          <v-btn
+            type="submit"
+            color="accent"
+            depressed
+            height="40"
+            max-width="90"
+            outlined
+            tile
+            small
+            class="resut-btn text-h6 ma-0 px-1 pb-1 flex-grow-1 flex-shrink-0"
+          >
+            =
+          </v-btn>
+          <div
+            class="result-text accent--text ma-0 py-1 flex-grow-1 flex-shrink-0"
+          >
+            <span class="text-h6">
+              {{ bmr }}
+            </span>
+            <span class="text-body-2"> kcal/日 </span>
+          </div>
+        </div>
+
+        <div class="captions text-caption accent--text mt-6">
+          <p>
+            ※
+            厚生労働省制定「日本人の食事摂取基準（2020年版）」参考におおよその値を算出。
+          </p>
+          <p>
+            ※
+            日常的に家事・通勤などでの歩行運動やスポーツなどの身体活動を行なっている場合は、必要なエネルギー量は多くなります。
+          </p>
+        </div>
+      </v-form>
+    </validation-observer>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      railsErrors: {
+        show: false,
+        message: '',
+        errorMessages: [],
+      },
+      age: null,
+      gender: '',
+    };
+  },
+  computed: {
+    bmr: {
+      get() {
+        return this.$store.state.bmrParams.bmr;
+      },
+      set(value) {
+        this.$store.commit('bmrParams/updateBmr', value);
+      },
+    },
+  },
+  methods: {
+    submit() {
+      this.$emit('click', this.age, this.gender);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.form-group {
+  text-align: center;
+}
+
+.v-text-field {
+  max-width: 350px;
+  padding: 0;
+}
+
+.v-input.form-item {
+  margin: 0 auto;
+}
+
+.v-btn.resut-btn {
+  background-color: rgb(44, 76, 107);
+  border: 1px solid rgb(245, 245, 246);
+  box-sizing: border-box;
+}
+
+.raido-btn-outline {
+  border: 1.5px solid rgb(245, 245, 246);
+  max-width: 350px;
+  height: 40px;
+}
+
+.raido-btn-outline.gender {
+  height: 100%;
+}
+
+.result {
+  max-width: 350px;
+}
+
+.result-text {
+  border-top: 1px solid rgb(245, 245, 246);
+  border-bottom: 1px solid rgb(245, 245, 246);
+  border-right: 1px solid rgb(245, 245, 246);
+  text-align: center;
+  min-width: 150px;
+  height: 40px;
+}
+
+.captions {
+  margin: 0 auto;
+  max-width: 350px;
+  text-align: start;
+  /* 2行目以降を1字下げ */
+  padding-left: 1rem;
+  text-indent: -1rem;
+}
+
+/* outlinedの場合 */
+.v-text-field.form-item >>> .v-input__slot {
+  border-radius: 0;
+  border: 1px solid rgb(245, 245, 246);
+}
+
+/* スイッチのラベル */
+.v-input--radio-group >>> .v-label {
+  margin-right: 20px;
+}
+</style>


### PR DESCRIPTION
## 概要
トライアル機能の使用をもっと簡単に行えるように、フォームの簡略化を行った。
計算式を用いてBMRを算出する方式から、「日本人の食事摂取基準（2020年版）」を参考に
計算をせずおおよその目標量を返す方式をとった。

それにより、トライアル用のフォームは性別とおおまかな年代の２要素のラジオボタンのみに
変更した。

<br />


## チェックリスト
- [x] コントローラーの修正
- [x] 簡易版フォームの作成
- [x] フロントの修正
- [x] リントチェック
- [x] 動作確認

<br />

closes #90
